### PR TITLE
[WIP][ENH] Participant and session in config file

### DIFF
--- a/dcm2bids/dcm2bids.py
+++ b/dcm2bids/dcm2bids.py
@@ -38,7 +38,8 @@ class Dcm2bids(object):
     """
 
     def __init__(
-            self, dicom_dir, config, participant=DEFAULT.participant, output_dir=DEFAULT.outputDir,
+            self, dicom_dir, config, participant=DEFAULT.participant,
+            output_dir=DEFAULT.outputDir,
             session=DEFAULT.session, clobber=DEFAULT.clobber,
             forceDcm2niix=DEFAULT.forceDcm2niix, log_level=DEFAULT.logLevel,
             **_):
@@ -52,13 +53,13 @@ class Dcm2bids(object):
         self.forceDcm2niix = forceDcm2niix
         self.logLevel = log_level
 
-        #logging setup
+        # logging setup
         self.set_logger()
 
         self.logger.info("--- dcm2bids start ---")
         self.logger.info("OS:version: {}".format(platform.platform()))
         self.logger.info("python:version: {}".format(
-            sys.version.replace("\n","")))
+            sys.version.replace("\n", "")))
         self.logger.info("dcm2bids:version: {}".format(__version__))
         self.logger.info("dcm2niix:version: {}".format(dcm2niix_version()))
         self.logger.info("participant: {}".format(self.participant.name))
@@ -67,18 +68,16 @@ class Dcm2bids(object):
         self.logger.info(
                 "BIDS directory: {}".format(os.path.realpath(output_dir)))
 
-
     @property
     def dicomDirs(self):
         return self._dicomDirs
-
 
     @dicomDirs.setter
     def dicomDirs(self, value):
         if isinstance(value, list):
             self._dicomDirs = value
         else:
-            self._dicomDirs = [value,]
+            self._dicomDirs = [value, ]
 
     def set_logger(self):
         """ Set a basic logger"""
@@ -86,8 +85,8 @@ class Dcm2bids(object):
         logFile = os.path.join(logDir, "{}_{}.log".format(
                 self.participant.prefix, datetime.now().isoformat()))
 
-        #os.makedirs(logdir, exist_ok=True)
-        #python2 compatibility
+        # os.makedirs(logdir, exist_ok=True)
+        # python2 compatibility
         if not os.path.exists(logDir):
             os.makedirs(logDir)
 
@@ -99,11 +98,13 @@ class Dcm2bids(object):
         session = self.participant.session
         participant = self.participant.name
 
-        participant = re.match(self.config["participant"]["expression"], sidecar._data[self.config["participant"]["dcmTag"]])
+        participant = re.match(self.config["participant"]["expression"],
+                               sidecar._data[self.config["participant"]["dcmTag"]])
         participant = participant.groups()[0]
 
         if "session" in self.config:
-            session = re.match(self.config["session"]["expression"], sidecar._data[self.config["session"]["dcmTag"]])
+            session = re.match(self.config["session"]["expression"],
+                               sidecar._data[self.config["session"]["dcmTag"]])
             session = session.groups()[0]
 
         self.participant = Participant(participant, session)
@@ -112,11 +113,16 @@ class Dcm2bids(object):
         """
         """
         if not self.participant.name:
-            dcm2niix = Dcm2niix(self.dicomDirs, self.bidsDir, "",
-                    self.config.get("dcm2niixOptions", DEFAULT.dcm2niixOptionsNA))
+            dcm2niix = Dcm2niix(self.dicomDirs,
+                                self.bidsDir,
+                                "",
+                                self.config.get("dcm2niixOptions",
+                                                DEFAULT.dcm2niixOptionsNA))
         else:
-            dcm2niix = Dcm2niix(self.dicomDirs, self.bidsDir, self.participant,
-                            self.config.get("dcm2niixOptions", DEFAULT.dcm2niixOptions))
+            dcm2niix = Dcm2niix(self.dicomDirs,
+                                self.bidsDir,
+                                self.participant,
+                                self.config.get("dcm2niixOptions", DEFAULT.dcm2niixOptions))
 
         dcm2niix.run(self.forceDcm2niix)
 
@@ -129,8 +135,10 @@ class Dcm2bids(object):
         if not self.participant.name and "participant" in self.config:
             self.setParticipant(sidecars[0])
 
-        parser = SidecarPairing(sidecars, self.config["descriptions"],
-                self.config.get("searchMethod", DEFAULT.searchMethod))
+        parser = SidecarPairing(sidecars,
+                                self.config["descriptions"],
+                                self.config.get("searchMethod",
+                                                DEFAULT.searchMethod))
         parser.build_graph()
         parser.build_acquisitions(self.participant)
         parser.find_runs()
@@ -144,7 +152,6 @@ class Dcm2bids(object):
 
         return os.EX_OK
 
-
     def move(self, acquisition):
         """
         """
@@ -152,12 +159,12 @@ class Dcm2bids(object):
             root, ext = splitext_(srcFile)
             dstFile = os.path.join(self.bidsDir, acquisition.dstRoot + ext)
 
-            #os.makedirs(os.path.dirname(dstFile), exist_ok=True)
-            #python2 compatibility
+            # os.makedirs(os.path.dirname(dstFile), exist_ok=True)
+            # python2 compatibility
             if not os.path.exists(os.path.dirname(dstFile)):
                 os.makedirs(os.path.dirname(dstFile))
 
-            #checking if destination file exists
+            # checking if destination file exists
             if os.path.isfile(dstFile):
                 self.logger.info("'{}' already exists".format(dstFile))
 
@@ -168,10 +175,10 @@ class Dcm2bids(object):
                     self.logger.info("Use clobber option to overwrite")
                     continue
 
-            #it's an anat nifti file and the user using a deface script
+            # it's an anat nifti file and the user using a deface script
             if (
                     self.config.get("defaceTpl")
-                    and acquisition.dataType=="anat"
+                    and acquisition.dataType == "anat"
                     and ".nii" in ext):
                 try:
                     os.remove(dstFile)
@@ -181,12 +188,12 @@ class Dcm2bids(object):
                 cmd = defaceTpl.format(srcFile=srcFile, dstFile=dstFile)
                 run_shell_command(cmd)
 
-            #use
+            # use
             elif ext == ".json":
                 data = acquisition.dstSidecarData(self.config["descriptions"])
                 save_json(dstFile, data)
                 os.remove(srcFile)
 
-            #just move
+            # just move
             else:
                 os.rename(srcFile, dstFile)

--- a/dcm2bids/dcm2niix.py
+++ b/dcm2bids/dcm2niix.py
@@ -110,4 +110,3 @@ class Dcm2niix(object):
 
             self.logger.debug("\n" + output)
             self.logger.info("Check log file for dcm2niix output")
-

--- a/dcm2bids/structure.py
+++ b/dcm2bids/structure.py
@@ -36,7 +36,11 @@ class Participant(object):
     @name.setter
     def name(self, name):
         """ Prepend 'sub-' if necessary"""
-        if name.startswith("sub-"):
+
+        if name.strip() == "":
+            self._name = ""
+
+        elif name.startswith("sub-"):
             self._name = name
 
         else:
@@ -273,4 +277,3 @@ class Acquisition(object):
 
         else:
             return char + value
-

--- a/dcm2bids/structure.py
+++ b/dcm2bids/structure.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
-
-
-from collections import OrderedDict
 from future.utils import iteritems
 from os.path import join as opj
 from .utils import DEFAULT
@@ -23,7 +20,6 @@ class Participant(object):
         self.name = name
         self.session = session
 
-
     @property
     def name(self):
         """
@@ -31,7 +27,6 @@ class Participant(object):
             A string 'sub-<subject_label>'
         """
         return self._name
-
 
     @name.setter
     def name(self, name):
@@ -46,7 +41,6 @@ class Participant(object):
         else:
             self._name = "sub-" + name
 
-
     @property
     def session(self):
         """
@@ -54,7 +48,6 @@ class Participant(object):
             A string 'ses-<session_label>'
         """
         return self._session
-
 
     @session.setter
     def session(self, session):
@@ -67,7 +60,6 @@ class Participant(object):
 
         else:
             self._session = "ses-" + session
-
 
     @property
     def directory(self):
@@ -82,7 +74,6 @@ class Participant(object):
         else:
             return self.name
 
-
     @property
     def prefix(self):
         """ The prefix to build filenames
@@ -96,7 +87,6 @@ class Participant(object):
         else:
             return self.name
 
-
     def hasSession(self):
         """ Check if a session is set
 
@@ -104,7 +94,6 @@ class Participant(object):
             Boolean
         """
         return not self.session.strip() == DEFAULT.session
-
 
 
 class Acquisition(object):
@@ -120,8 +109,8 @@ class Acquisition(object):
     """
 
     def __init__(self, participant, dataType, modalityLabel, customLabels="",
-            srcSidecar=None, sidecarChanges={},
-            intendedFor=None, IntendedFor=None, **kwargs):
+                 srcSidecar=None, sidecarChanges={},
+                 intendedFor=None, IntendedFor=None, **kwargs):
         self._modalityLabel = ""
         self._customLabels = ""
         self._intendedFor = None
@@ -137,14 +126,12 @@ class Acquisition(object):
         else:
             self.intendedFor = intendedFor
 
-
     def __eq__(self, other):
         return (
                 self.dataType == other.dataType
                 and self.participant.prefix == other.participant.prefix
                 and self.suffix == other.suffix
                 )
-
 
     @property
     def modalityLabel(self):
@@ -154,12 +141,10 @@ class Acquisition(object):
         """
         return self._modalityLabel
 
-
     @modalityLabel.setter
     def modalityLabel(self, modalityLabel):
         """ Prepend '_' if necessary"""
         self._modalityLabel = self.prepend(modalityLabel)
-
 
     @property
     def customLabels(self):
@@ -169,12 +154,10 @@ class Acquisition(object):
         """
         return self._customLabels
 
-
     @customLabels.setter
     def customLabels(self, customLabels):
         """ Prepend '_' if necessary"""
         self._customLabels = self.prepend(customLabels)
-
 
     @property
     def suffix(self):
@@ -188,7 +171,6 @@ class Acquisition(object):
         else:
             return self.customLabels + self.modalityLabel
 
-
     @property
     def srcRoot(self):
         """
@@ -199,7 +181,6 @@ class Acquisition(object):
             return self.srcSidecar.root
         else:
             return None
-
 
     @property
     def dstRoot(self):
@@ -213,19 +194,16 @@ class Acquisition(object):
                 self.participant.prefix + self.suffix
                 )
 
-
     @property
     def intendedFor(self):
         return self._intendedFor
-
 
     @intendedFor.setter
     def intendedFor(self, value):
         if isinstance(value, list):
             self._intendedFor = value
         else:
-            self._intendedFor = [value,]
-
+            self._intendedFor = [value, ]
 
     def dstSidecarData(self, descriptions):
         """
@@ -233,7 +211,7 @@ class Acquisition(object):
         data = self.srcSidecar.origData
         data["Dcm2bidsVersion"] = __version__
 
-        #intendedFor key
+        # intendedFor key
         if self.intendedFor != [None]:
             intendedValue = []
             for index in self.intendedFor:
@@ -254,12 +232,11 @@ class Acquisition(object):
             else:
                 data["IntendedFor"] = intendedValue
 
-        #sidecarChanges
+        # sidecarChanges
         for key, value in iteritems(self.sidecarChanges):
             data[key] = value
 
         return data
-
 
     @staticmethod
     def prepend(value, char="_"):

--- a/dcm2bids/utils.py
+++ b/dcm2bids/utils.py
@@ -7,38 +7,38 @@ import logging
 import os
 import shlex
 from collections import OrderedDict
-from subprocess import check_output, CalledProcessError
+from subprocess import check_output
 
 
 class DEFAULT(object):
     """ Default values of the package"""
-    #cli dcm2bids
+    # cli dcm2bids
     cliSession = ""
     cliOutputDir = os.getcwd()
     cliLogLevel = "INFO"
     cliParticipant = ""
 
-    #dcm2bids.py
+    # dcm2bids.py
     outputDir = cliOutputDir
-    session = cliSession #also Participant object
+    session = cliSession  # also Participant object
     participant = cliParticipant
     clobber = False
     forceDcm2niix = False
     defaceTpl = None
     logLevel = "WARNING"
 
-    #dcm2niix.py
+    # dcm2niix.py
     dcm2niixOptions = "-b y -ba y -z y -f '%3s_%f_%p_%t'"
     dcm2niixOptionsNA = "-b y -ba n -z y -f '%3s_%f_%p_%t'"
     dcm2niixVersion = "v1.0.20181125"
 
-    #sidecar.py
+    # sidecar.py
     compKeys = ["SeriesNumber", "AcquisitionTime", "SidecarFilename"]
     searchMethod = "fnmatch"
     searchMethodChoices = ["fnmatch", "re"]
     runTpl = "_run-{:02d}"
 
-    #misc
+    # misc
     tmpDirName = "tmp_dcm2bids"
     helperDir = "helper"
 
@@ -68,7 +68,7 @@ def write_txt(filename, lines=[]):
             f.write("%s\n" % row)
 
 
-def write_participants(filename,participants):
+def write_participants(filename, participants):
     with open(filename, 'w') as f:
         writer = csv.DictWriter(f, delimiter='\t',
                                 fieldnames=participants[0].keys())

--- a/dcm2bids/utils.py
+++ b/dcm2bids/utils.py
@@ -16,10 +16,12 @@ class DEFAULT(object):
     cliSession = ""
     cliOutputDir = os.getcwd()
     cliLogLevel = "INFO"
+    cliParticipant = ""
 
     #dcm2bids.py
     outputDir = cliOutputDir
     session = cliSession #also Participant object
+    participant = cliParticipant
     clobber = False
     forceDcm2niix = False
     defaceTpl = None
@@ -27,6 +29,7 @@ class DEFAULT(object):
 
     #dcm2niix.py
     dcm2niixOptions = "-b y -ba y -z y -f '%3s_%f_%p_%t'"
+    dcm2niixOptionsNA = "-b y -ba n -z y -f '%3s_%f_%p_%t'"
     dcm2niixVersion = "v1.0.20181125"
 
     #sidecar.py
@@ -107,4 +110,3 @@ def run_shell_command(commandLine):
     logger = logging.getLogger(__name__)
     logger.info("Running {}".format(commandLine))
     return check_output(shlex.split(commandLine))
-

--- a/docs/advance.md
+++ b/docs/advance.md
@@ -46,3 +46,22 @@ default: `"compKeys": ["SeriesNumber", "AcquisitionTime", "SidecarFilename"]`
 
 Acquisitions are sorted using the sidecar data. The default behaviour is to sort by `SeriesNumber` then by `AcquisitionTime` then by the `SidecarFilename`. You can change this behaviour setting this key inside the configuration file.
 
+## participant and session
+
+There are two ways to give the participant `<PARTICIPANT_ID>` and session `<SESSION_ID>`:
+
+1. Through the command line using the arguments `-p` and `-s`
+2. Through the config file, using a specific sidecar and a REGEX expression to grab the exact string.
+
+```
+ "participant": {
+    "dcmTag": "PatientName",
+    "expression": "[0-9a-zA-Z]*_sub-([0-9a-zA-Z]*)_sess-[0-9a-zA-Z]*"
+    },
+"session": {
+    "dcmTag": "PatientName",
+    "expression": "[0-9a-zA-Z]*_sub-[0-9a-zA-Z]*_sess-([0-9a-zA-Z]*)"
+    }
+```
+
+**WARNING**: if you choose a sidecar that will be removed because of anonymisation you need to use this dcm2niix option: `"dcm2niixOptions": "-b y -ba n -z y -f '%3s_%f_%p_%t'"`

--- a/scripts/dcm2bids
+++ b/scripts/dcm2bids
@@ -27,7 +27,7 @@ dcm2bids {}""".format(__version__),
 
     parser.add_argument(
             "-p", "--participant",
-            required=True,
+            required=False, default=DEFAULT.participant,
             help="Participant ID",
             )
 


### PR DESCRIPTION
The main idea is to be able to run dcm2bids without the need to give the subject (and session).
We suggest to add into the config file two new keys: participant and session.

```
"participant": {
    "dcmTag": "PatientName",
    "expression": "[0-9a-zA-Z]*_sub-([0-9a-zA-Z]*)_sess-[0-9a-zA-Z]*"
    },
"session": {
    "dcmTag": "PatientName",
    "expression": "[0-9a-zA-Z]*_sub-[0-9a-zA-Z]*_sess-([0-9a-zA-Z]*)"
    }
```
**dcmTag** referes to your favorite dicom tag. For example: PatientName => project_sub-01_sess-01
**expression** is a REGEX expression in order to grab the relevant information.