### PR TITLE
support directories containing spaces

### DIFF
--- a/dcm2bids/dcm2niix.py
+++ b/dcm2bids/dcm2niix.py
@@ -95,7 +95,7 @@ class Dcm2niix(object):
         """ Execute dcm2niix for each directory in dicomDirs
         """
         for dicomDir in self.dicomDirs:
-            commandTpl = "dcm2niix {} -o {} {}"
+            commandTpl = "dcm2niix {} -o '{}' '{}'"
             cmd = commandTpl.format(self.options, self.outputDir, dicomDir)
             output = run_shell_command(cmd)
 


### PR DESCRIPTION
I manually made this change to account for directly converting my files on Google Drive Streaming, which names directories "My Drive" or "Shared Drives" without change permissions.