### PR TITLE
Use shlex's posix=False for Windows compatibility

### DIFF
--- a/dcm2bids/utils.py
+++ b/dcm2bids/utils.py
@@ -109,4 +109,4 @@ def run_shell_command(commandLine):
     """
     logger = logging.getLogger(__name__)
     logger.info("Running %s", commandLine)
-    return check_output(shlex.split(commandLine))
+    return check_output(shlex.split(commandLine, posix=False))


### PR DESCRIPTION
Fixes #83.

I'm a little bit worried this will cause problems on Unix. I tried it quickly and it didn't break my examples.

Maybe `utils.run_shell_command()` should be dropped in favour of calling `subprocess.Popen()` directly. It's a lot safer that way; less worries about quoting issues turning into exploits.