### PR TITLE
[ENH, FIX] Update documentation based on #120

### DIFF
--- a/.github/workflows/publish_doc.yaml
+++ b/.github/workflows/publish_doc.yaml
@@ -1,0 +1,30 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+    - name: run portray
+      run: |
+        portray as_html
+    - name: Deploy to gh-pages branch
+      uses: peaceiris/actions-gh-pages@v3.7.3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./site

--- a/.github/workflows/publish_doc.yaml
+++ b/.github/workflows/publish_doc.yaml
@@ -1,4 +1,4 @@
-name: Python package
+name: Publish documentation
 
 on: [push]
 

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ tests/data/*
 !tests/data/config_test.json
 !tests/data/config_test_not_case_sensitive_option.json
 !tests/data/sidecars/*
+
+# dcm2bids documentation
+/site

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,30 +2,28 @@
 
 Each of us as a member of the dcm2bids community we ensure that every
 contributors enjoy their time contributing and helping people. Accordingly,
-
-everyone who participates in the development in any way possible is
- expected to show respect, courtesy to other community members including
- end-users who are seeking help on [Neurostars](https://neurostars.org/) or on [GitHub](https://github.com/UNFmontreal/Dcm2Bids/issues).
-
+everyone who participates in the development in any way possible is expected to
+show respect, courtesy to other community members including end-users who are
+seeking help on [Neurostars](https://neurostars.org/) or on
+[GitHub](https://github.com/UNFmontreal/Dcm2Bids/issues).
 
 We also encourage everybody regardless of age, gender identity, level of
-experience, nativa langage, race or religion to be involved in the project.
-We pledge to make participation in the dcm2bids project an harassment-free
+experience, native langage, race or religion to be involved in the project. We
+pledge to make participation in the dcm2bids project an harassment-free
 experience for everyone.
-
 
 ## Our standards
 
 We commit to promote any behavior that contributes to create a positive
- environment including:
-* Using welcoming and inclusive language
-* Being respectful
-* Show empathy towards everybody
-* Focusing on what is best for the community
+environment including:
+
+- Using welcoming and inclusive language;
+- Being respectful;
+- Show empathy towards everybody;
+- Focusing on what is best for the community.
 
 We do **NOT** tolerate harassment or inappropriate behavior in the dcm2bids
 community.
-
 
 ## Our responsibilities
 
@@ -33,19 +31,19 @@ Project maintainers are responsible for clarifying the standards of acceptable
 behavior and are expected to take appropriate and fair corrective action in
 response to any instances of unacceptable behavior.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
 
 ## Scope
 
-This Code of Conduct applies both within our online GitHub repository
-and in public spaces when an individual is representing the project or its community.
-Examples of representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event.
+This Code of Conduct applies both within our online GitHub repository and in
+public spaces when an individual is representing the project or its community.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event.
 
 ## Enforcement
 
@@ -54,24 +52,24 @@ reported by contacting Arnaud Boré at <arnaud.bore@criugm.qc.ca>.
 
 Confidentiality will be respected in reporting.
 
-As the first interim [Benevolent Dictator for Life (BDFL)](https://en.wikipedia.org/wiki/Benevolent_dictator_for_life), Arnaud Boré can take any action he deems
-appropriate for the safety of the dcm2bids community, including but not
-limited to:
-* facilitating a conversation between the two parties involved in the
-violation of the code of conduct
-* requesting a contributor apologize for their behavior
-* asking a contributor or multiple contributors to enter a cooling off period
- that puts a time-limited pause on a particular discussion topic
-* asking a contributor to no longer participate in the
-development of *dcm2bids*
+As the first interim
+[Benevolent Dictator for Life (BDFL)](https://en.wikipedia.org/wiki/Benevolent_dictator_for_life),
+Arnaud Boré can take any action he deems appropriate for the safety of the
+dcm2bids community, including but not limited to:
+
+- facilitating a conversation between the two parties involved in the violation
+  of the code of conduct;
+- requesting a contributor apologize for their behavior;
+- asking a contributor or multiple contributors to enter a cooling off period
+  that puts a time-limited pause on a particular discussion topic;
+- asking a contributor to no longer participate in the development of _dcm2bids_.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
-as well as Code of Conduct from the [tedana][tedana-repo] and
-[STEMMRoleModels][stem-repo] projects.
+This Code of Conduct was adapted from the [Contributor Covenant][covenant-home],
+version 1.4, available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html][covenant-coc] as well as Code of Conduct from the [tedana][tedana-repo] and [STEMMRoleModels][stem-repo] projects.
 
 [stem-repo]: https://github.com/KirstieJane/STEMMRoleModels
 [tedana-repo]: https://github.com/ME-ICA/tedana
-[homepage]: https://www.contributor-covenant.org/
+[covenant-home]: https://www.contributor-covenant.org/
+[covenant-coc]: https://www.contributor-covenant.org/version/1/4/code-of-conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,133 +1,177 @@
 # Contributing to dcm2bids
 
-Welcome to the dcm2bids repository and thank you for thinking about
- contributing! :heart:
+Welcome to the `dcm2bids` repository and thank you for thinking about
+contributing! :heart:
 
 This document has been written in such a way you feel at ease to find your way
- on how you can make a difference for the `dcm2bids` community.
+on how you can make a difference for the `dcm2bids` community.
 
 We tried to cover as much as possible in few words possible. If you have any
 questions don't hesitate to share them in the section below.
 
-There are multiple ways to be helpful to the dcm2bids community.
+There are multiple ways to be helpful to the `dcm2bids` community.
 
-If you already know what you are looking for, you can select one of the section below:
+If you already know what you are looking for, you can select one of the section
+below:
 
-* [Welcome](#welcome)
-* [Contributing through Neurostars](#contributing-through-neurostars)
-* [Contributing through Github ](#contributing-through-github)
-  + [Create a pull request](#create-a-pull-request)
-  + [Create an issue](#create-a-pull-request)
-  + [Fork the dcm2bids repository](#fork-the-dcm2bids-repository)
-  + [Test your branch](#test-your-branch)
-  + [Check list](#check-list)
-  + [Submit and tag your pull request](#submit-and-tag-your-pull-request)
-  + [Create an issue, tag with labels and contribute](#create-an-issue,-tag-with-labels-and-contribute)
-* [Recognizing your contribution](#recognizing-your-contribution)
+- [Contributing to dcm2bids](#contributing-to-dcm2bids)
+  - [Welcome](#welcome)
+  - [Contributing through Neurostars](#contributing-through-neurostars)
+  - [Contributing through GitHub](#contributing-through-github)
+  - [Recommended workflow](#recommended-workflow)
+    - [Open an issue or choose one to fix](#open-an-issue-or-choose-one-to-fix)
+    - [Fork the `dcm2bids` repository](#fork-the-dcm2bids-repository)
+    - [Test your branch](#test-your-branch)
+    - [Check list](#check-list)
+    - [Submit and tag your pull request](#submit-and-tag-your-pull-request)
+  - [Recognizing your contribution](#recognizing-your-contribution)
+  - [Thank you!](#thank-you)
 
-Don't know where to get started?
-Read [Welcome](#welcome) and pop into
-this [thread][dcm2bids-introduce-yourself] to introduce yourself! Let us know what your interests are and we
-will help you find an issue to contribute to. Thanks so much!
+If you don't know where or how to get started, keep on reading below. 
 
 ## Welcome
 
-dcm2bids is a small project started in 2017 by Christophe Bedetti([@cbedetti](https://github.com/cbedetti)).
-Now 2021, we are starting a new initiative and we're excited to have you join!
-You can introduce yourself on the open issue [welcome][dcm2bids-welcome] and
-tell us how you would like to contribute in the `dcm2bids` community.
-Most of our discussions will take place on open [issues][dcm2bids-issues].
+`dcm2bids` is a small project started in 2017 by Christophe Bedetti
+([@cbedetti](https://github.com/cbedetti)). In 2021, we have started a
+new initiative and we're excited to have you join!
 
-As a reminder, we expect all contributions to `dcm2bids` to adhere
-to our [code of conduct][dcm2bids-coc].
+You can introduce yourself on
+the open issue [welcome][dcm2bids-introduce-yourself] and tell us how you would like to
+contribute in the `dcm2bids` community. Let us know what your interests are and
+we will help you find an issue to contribute to if you haven't already spotted one yet. Most of our discussions will take place
+on open [issues][dcm2bids-issues]. Thanks so much! As a reminder, we expect all contributions to `dcm2bids` to adhere to our [Code
+of Conduct][dcm2bids-coc].
 
 ## Contributing through Neurostars
 
-The dcm2bids community highlight all contributions to `dcm2bids`.
-Helping users on Neurostars forum is one of them.
+The `dcm2bids` community highlight all contributions to `dcm2bids`. Helping users
+on [Neurostars](https://neurostars.org) forum is one of them.
 
 Neurostars has a `dcm2bids` tag that helps us following any question regarding
-the project. You can ask for Neurostars to send you notifications when a new
- message has been posted. If you know the answer, you can reply following
- our [code of conduct][dcm2bids-coc].
+the project. You can ask Neurostars to notify you when a new message tagged with `dcm2bids` has been posted. If you know the answer, you can reply following our
+[code of conduct][dcm2bids-coc].
+
+??? info "How to receive email notifications from Neurostars"
+    If you want to receive email notifications, you have to go set your settings accordingly on Neurostars. The procedure below will get you to this (personalized) URL: https://neurostars.org/u/**YOURUSERNAME**/preferences/tags :
+
+    1. Click on your picture in the top right corner
+    2. Click on the 👤 (user) icon
+    3. Click on ⚙️ **Preferences**
+    4. Click on **Notifications**
+    5. Click on **Tags**
+    6. We recommend to add `dcm2bids` to the **Watched** section, but you can add it to any section that fits your need.
 
 ## Contributing through GitHub
 
-[Git][link_git] is a really useful tool for version control.
-[GitHub][link_github] sits on top of git and supports collaborative and distributed working.
+[Git][link_git] is a really useful tool for [version control][vcs].
+[GitHub][link_github] sits on top of git and supports collaborative and
+distributed working.
 
-Before you start you'll need to set up a free [GitHub][link_github] account and sign in.
-Here are some [instructions][link_signupinstructions].
+Before you start you'll need to set up a free [GitHub][link_github] account and
+sign in. You can sign up [through this link][link_github_signup] and then _interact_ on our repository at [https://github.io/UNFmontreal/Dcm2Bids](https://github.io/UNFmontreal/Dcm2Bids).
 
-You'll use [Markdown][markdown] to chat in issues and pull requests on GitHub.
-You can think of Markdown as a few little symbols around your text that will allow GitHub
-to render the text with a little bit of formatting.
-For example you could write words as bold (`**bold**`), or in italics (`*italics*`),
-or as a [link][rick_roll] (`[link](https://https://youtu.be/dQw4w9WgXcQ)`) to another webpage.
+You'll use [Markdown][markdown] to discuss in issues and pull requests on
+GitHub. You can think of Markdown as a few little symbols around your text that
+will allow GitHub to render the text with a little bit of formatting. For
+example you can write words as **bold** (`**bold**`), or in _italics_
+(`*italics*`), or as a [link](https://youtu.be/dQw4w9WgXcQ)
+(`[link](https://youtu.be/dQw4w9WgXcQ)`) to another webpage.
 
-GitHub has a helpful page on
-[getting started with writing and formatting Markdown on GitHub][writing_formatting_github].
+!!! info "Did you know?"
+    Most software documentation websites are written in Markdown. Even the `dcm2bids` [documentation website][dcm2bids-doc] is written in Markdown!
 
-### Create a pull request
+    GitHub has a helpful page on [getting started with writing and formatting Markdown on GitHub][writing_formatting_github].
 
-We will be excited when you'll suggest a new PR to fix, enhance or develop `dcm2bids`.
-In order to make this as fluid as possible we recommend to follow this workflow:
+## Recommended workflow
 
-### Create an issue
+We will be excited when you'll suggest a new PR to fix, enhance or develop
+`dcm2bids`. In order to make this as fluid as possible we recommend to follow
+this workflow:
 
-Before starting to work on a new pull request we highly recommend you open an
- issue with the label *enhancement* to explain what you want to do and how it
- echoes a specific demand from the community. Moreover, it will be
- interesting to see how others approach your issue and give their opinion and
- maybe give you advice to find the best way to code it. Finally, it will prevent
- you to start working on something that is already in progress.
- Keep in mind the [scope][dcm2bids-scope] of the `dcm2bids` project.
+### Open an issue or choose one to fix
+
+Issues are individual pieces of work that need to be completed to move the
+project forwards. Before starting to work on a new pull request we highly
+recommend you open an issue to explain what you want to do and how it echoes a
+specific demand from the community. Keep in mind the [scope][dcm2bids-scope] of
+the `dcm2bids` project.
+
+A general guideline: if you find yourself tempted to write a great big issue
+that is difficult to describe as one unit of work, please consider splitting it
+into two or more. Moreover, it will be interesting to see how others approach
+your issue and give their opinion and maybe give you advice to find the best way
+to code it. Finally, it will prevent you to start working on something that is
+already in progress.
+
+The list of all labels is [here][dcm2bids-labels] and include:
+
+- [![Help Wanted](https://img.shields.io/badge/-help%20wanted-159818.svg)][link_helpwanted]
+  _These issues contain a task that a member of the team has determined we need
+  additional help with._
+
+  If you feel that you can contribute to one of these issues, we especially
+  encourage you to do so!
+
+- [![Bug](https://img.shields.io/badge/-bug-fc2929.svg)][link_bugs] _These
+  issues point to problems in the project._
+
+  If you find new a bug, please give as much detail as possible in your issue,
+  including steps to recreate the error. If you experience the same bug as one
+  already listed, please add any additional information that you have as a
+  comment.
+
+- [![Enhancement](https://img.shields.io/badge/-enhancement-84b6eb.svg)][link_enhancement]
+  _These issues are asking for enhancements to be added to the project._
+
+  Please try to make sure that your enhancement is distinct from any others that
+  have already been requested or implemented. If you find one that's similar but
+  there are subtle differences please reference the other request in your issue.
 
 ### Fork the `dcm2bids` repository
 
-This way you'll be able to work on your own instance of `dcm2bids`. It will be
-a safe place where nothing can affect the main repository. Make sure your
-master is always [up-to-date][git-fork-update]. You can also follow these
-command lines.
+This way you'll be able to work on your own instance of `dcm2bids`. It will be a
+safe place where nothing can affect the main repository. Make sure your master
+branch is always [up-to-date][git-fork-update] with dcm2bids' master branch. You
+can also follow these command lines.
 
-```
+```bash
 git checkout master
 git fetch upstream master
 git merge upstream/master
 ```
 
-Then create a new branch for each issue. Using a new branch allows you to
-follow the standard GitHub workflow when making changes.
-[This guide][git-guide] provides a useful overview for this workflow.
-Please keep the name of your branch short and self explanatory.
+Then create a new branch for each issue. Using a new branch allows you to follow
+the standard GitHub workflow when making changes. [This guide][git-guide]
+provides a useful overview for this workflow. Please keep the name of your
+branch short and self explanatory.
 
-```
+```bash
 git checkout -b MYBRANCH
 ```
 
 ### Test your branch
 
-If you are proposing new features, you'll need to add new tests as well.
-In any case, you have to test your branch prior to submit your PR.
+If you are proposing new features, you'll need to add new tests as well. In any
+case, you have to test your branch prior to submit your PR.
 
 If you have new code you will have to run pytest:
 
-```
+```bash
 pytest -v tests/test_dcm2bids.py
 ```
 
-`dcm2bids` project is following [PEP8][pep8] convention whenever possible.
-You can check your code using this command line:
+`dcm2bids` project is following [PEP8][pep8] convention whenever possible. You
+can check your code using this command line:
 
-```
+```bash
 flake8 FileIWantToCheck
 ```
 
 Regardless, when you open a Pull Request, we use [Tox][tox] to run all unit and
 integration tests.
 
-If you have propose a PR about a modification on the documentation you can
-have a preview from an editor like Atom using `CTRL+SHIFT+M`.
+If you have propose a PR about a modification on the documentation you can have
+a preview from an editor like Atom using `CTRL+SHIFT+M`.
 
 ### Check list
 
@@ -141,58 +185,51 @@ Pull Request Checklist (For Fastest Review):
 
 ### Submit and tag your pull request
 
-When you submit a pull request we ask you to follow the tag specification. In order to simplify reviewers work, we ask you to use at least one of the following tags:
+When you submit a pull request we ask you to follow the tag specification. In
+order to simplify reviewers work, we ask you to use at least one of the
+following tags:
 
-* [BRK] for changes which break existing builds or tests
-* [DOC] for new or updated documentation
-* [ENH] for enhancements
-* [FIX] for bug fixes
-* [TST] for new or updated tests
-* [REF] for refactoring existing code
-* [MAINT] for maintenance of code
-* [WIP] for work in progress
+- [BRK] for changes which break existing builds or tests
+- [DOC] for new or updated documentation
+- [ENH] for enhancements
+- [FIX] for bug fixes
+- [TST] for new or updated tests
+- [REF] for refactoring existing code
+- [MAINT] for maintenance of code
+- [WIP] for work in progress
 
-You can also combine the tags above, for example if you are updating both a test and the documentation: [TST, DOC].
-
-
-### Create an issue, tag with labels and contribute
-
-Issues are individual pieces of work that need to be completed to move the project forwards. A general guideline: if you find yourself tempted to write a great big issue that is difficult to describe as one unit of work, please consider splitting it into two or more.
-
-The current list of labels are [here][dcm2bids-labels] and include:
-
-* [![Help Wanted](https://img.shields.io/badge/-help%20wanted-159818.svg)][link_helpwanted] *These issues contain a task that a member of the team has determined we need additional help with.*
-
-    If you feel that you can contribute to one of these issues, we especially encourage you to do so!
-
-* [![Bug](https://img.shields.io/badge/-bug-fc2929.svg)][link_bugs] *These issues point to problems in the project.*
-
-    If you find new a bug, please give as much detail as possible in your issue, including steps to recreate the error.
-    If you experience the same bug as one already listed, please add any additional information that you have as a comment.
-
-* [![Enhancement](https://img.shields.io/badge/-enhancement-84b6eb.svg)][link_enhancement] *These issues are asking for enhancements to be added to the project.*
-
-    Please try to make sure that your enhancement is distinct from any others that have already been requested or implemented.
-    If you find one that's similar but there are subtle differences please reference the other request in your issue.
-
+You can also combine the tags above, for example if you are updating both a test
+and the documentation: [TST, DOC].
 
 ## Recognizing your contribution
 
-We welcome and recognize [all contributions][link_all-contributors-spec]
-from documentation to testing to code development.
-You can see a list of current contributors in the [README](/README.md)
-(kept up to date by the [all contributors bot][link_all-contributors-bot]).
-You can see [here][link_all-contributors-bot-usage] for instructions on
-how to use the bot.
+We welcome and recognize [all contributions][link_all-contributors-spec] from
+documentation to testing to code development. You can see a list of current
+contributors in the [README](/README.md) (kept up to date by the [all
+contributors bot][link_all-contributors-bot]). You can see
+[here][link_all-contributors-bot-usage] for instructions on how to use the bot.
 
 ## Thank you!
 
 You're amazing. :wave::smiley:
 
-*&mdash; Based on contributing guidelines from the [STEMMRoleModels][link_stemmrolemodels] and [tedana][link_tedana] projects.*
+_&mdash; Based on contributing guidelines from the
+[STEMMRoleModels][link_stemmrolemodels] and [tedana][link_tedana] projects._
 
+---
+
+Help guide to write the documentation:
+
+- H~2~0
+- A^T^A
+- ==This was marked==
+- ^^This was inserted^^
+- ~~This was deleted~~
+
+[markdown]: https://en.wikipedia.org/wiki/Markdown
 [link_git]: https://git-scm.com/
 [link_github]: http://github.com/
+[link_github_signup]: https://github.com/join
 [link_tedana]: https://github.com/ME-ICA/tedana
 [link_stemmrolemodels]: https://github.com/KirstieJane/STEMMRoleModels
 [dcm2bids-labels]: https://github.com/UNFmontreal/Dcm2Bids/labels
@@ -201,13 +238,15 @@ You're amazing. :wave::smiley:
 [link_enhancement]: https://github.com/UNFmontreal/Dcm2Bids/labels/enhancement
 [dcm2bids-issues]: https://github.com/UNFmontreal/Dcm2Bids/issues
 [dcm2bids-coc]: https://unfmontreal.github.io/Dcm2Bids/CODE_OF_CONDUCT
-[dcm2bids-introduce-yourself]: https://github.com/UNFmontreal/Dcm2Bids/issues
-[writing_formatting_github]: https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github
+[dcm2bids-introduce-yourself]: https://github.com/UNFmontreal/Dcm2Bids/issues/108
+[dcm2bids-scope]: /#scope
+[dcm2bids-doc]: /
+[writing_formatting_github]: https://guides.github.com/features/mastering-markdown/
 [git-fork-update]: https://help.github.com/articles/syncing-a-fork/
 [git-guide]: https://guides.github.com/introduction/flow/
 [pep8]: https://www.python.org/dev/peps/pep-0008/
 [tox]: https://tox.readthedocs.io/
-
 [link_all-contributors-spec]: https://allcontributors.org/docs/en/specification
 [link_all-contributors-bot]: https://allcontributors.org/docs/en/bot/overview
 [link_all-contributors-bot-usage]: https://allcontributors.org/docs/en/bot/usage
+[vcs]: https://en.wikipedia.org/wiki/Version_control

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ example you can write words as **bold** (`**bold**`), or in _italics_
 !!! info "Did you know?"
     Most software documentation websites are written in Markdown. Even the `dcm2bids` [documentation website][dcm2bids-doc] is written in Markdown!
 
-    GitHub has a helpful page on [getting started with writing and formatting Markdown on GitHub][writing_formatting_github].
+    GitHub has a helpful guide to [get you started with writing and formatting Markdown][writing_formatting_github].
 
 ## Recommended workflow
 
@@ -177,11 +177,11 @@ a preview from an editor like Atom using `CTRL+SHIFT+M`.
 
 Pull Request Checklist (For Fastest Review):
 
-- Check that all tests are passing ("All tests passsed")
-- Make sure you have docstrings for any new functions
-- Make sure that docstrings are updated for edited functions
-- Make sure you note any issues that will be closed by your PR
-- Add a clear description of the purpose of you PR
+- [x] Check that all tests are passing ("All tests passsed")
+- [x] Make sure you have docstrings for any new functions
+- [x] Make sure that docstrings are updated for edited functions
+- [x] Make sure you note any issues that will be closed by your PR
+- [x] Add a clear description of the purpose of you PR
 
 ### Submit and tag your pull request
 
@@ -189,14 +189,14 @@ When you submit a pull request we ask you to follow the tag specification. In
 order to simplify reviewers work, we ask you to use at least one of the
 following tags:
 
-- [BRK] for changes which break existing builds or tests
-- [DOC] for new or updated documentation
-- [ENH] for enhancements
-- [FIX] for bug fixes
-- [TST] for new or updated tests
-- [REF] for refactoring existing code
-- [MAINT] for maintenance of code
-- [WIP] for work in progress
+- ==[BRK]== for changes which break existing builds or tests
+- ==[DOC]== for new or updated documentation
+- ==[ENH]== for enhancements
+- ==[FIX]== for bug fixes
+- ==[TST]== for new or updated tests
+- ==[REF]== for refactoring existing code
+- ==[MAINT]== for maintenance of code
+- ==[WIP]== for work in progress
 
 You can also combine the tags above, for example if you are updating both a test
 and the documentation: [TST, DOC].
@@ -217,14 +217,6 @@ _&mdash; Based on contributing guidelines from the
 [STEMMRoleModels][link_stemmrolemodels] and [tedana][link_tedana] projects._
 
 ---
-
-Help guide to write the documentation:
-
-- H~2~0
-- A^T^A
-- ==This was marked==
-- ^^This was inserted^^
-- ~~This was deleted~~
 
 [markdown]: https://en.wikipedia.org/wiki/Markdown
 [link_git]: https://git-scm.com/

--- a/README.md
+++ b/README.md
@@ -1,34 +1,24 @@
 # dcm2bids
 Your friendly DICOM converter.
 
-<p>
-<a href="https://pypi.org/project/dcm2bids">
-<img alt="PyPI version" src="https://badge.fury.io/py/dcm2bids.svg">
-</a>
-<a href="https://unfmontreal.github.io/Dcm2Bids">
-<img alt="Documentation" src="https://img.shields.io/badge/documentation-dcm2bids-succes.svg">
-</a>
-<a href="https://zenodo.org/badge/latestdoi/59581295">
-<img alt="DOI" src="https://zenodo.org/badge/doi/10.5281/zenodo.2616548.svg">
-</a>
-<!--
-<a href="https://singularity-hub.org/collections/544">
-<img alt="Singularity Hub" src="https://www.singularity-hub.org/static/img/hosted-singularity--hub-%23e32929.svg">
-</a>
--->
-</p>
+[![Documentation](https://img.shields.io/badge/Documentation-dcm2bids-succes.svg)](https://unfmontreal.github.io/Dcm2Bids)
+[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.2616548.svg)](https://zenodo.org/badge/latestdoi/59581295)
+[![Anaconda-Server Badge](https://anaconda.org/conda-forge/dcm2bids/badges/latest_release_date.svg)](https://anaconda.org/conda-forge/dcm2bids)
 
-<p>
-<a href="https://github.com/unfmontreal/Dcm2Bids/actionsk">
-<img alt="" src="https://github.com/unfmontreal/Dcm2Bids/workflows/Tests/badge.svg">
-</a>
-<a href="https://codecov.io/gh/unfmontreal/Dcm2Bids">
-<img src="https://codecov.io/gh/unfmontreal/Dcm2Bids/branch/master/graph/badge.svg"/>
-</a>
-<a href="https://github.com/psf/black">
-<img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg">
-</a>
-</p>
+
+[![](https://github.com/unfmontreal/Dcm2Bids/workflows/Tests/badge.svg)](https://github.com/unfmontreal/Dcm2Bids/actionsk)
+[![](https://codecov.io/gh/unfmontreal/Dcm2Bids/branch/master/graph/badge.svg)](https://codecov.io/gh/unfmontreal/Dcm2Bids)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+
+
+[![PyPI version](https://img.shields.io/pypi/v/dcm2bids)](https://pypi.org/project/dcm2bids)
+[![Anaconda-Server Badge](https://anaconda.org/conda-forge/dcm2bids/badges/version.svg)](https://anaconda.org/conda-forge/dcm2bids)
+[![Docker container](https://badgen.net/docker/pulls/unfmontreal/dcm2bids?icon=docker&label=pulls)](https://hub.docker.com/r/unfmontreal/dcm2bids)
+
+
+[![](https://img.shields.io/pypi/l/dcm2bids)](LICENSE.txt)
+
+---
 
 `dcm2bids` reorganises NIfTI files using [dcm2niix][dcm2niix-github] into the [Brain Imaging Data Structure][bids] (BIDS).
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ to day use case without complicating anything. That's the promise of the `dcm2bi
 Please take a look at the [documentation][dcm2bids-doc] to:
 
 * [Learn about bids][bids-spec] with some dataset [examples][bids-examples]
-* [Install dcm2niix][dcm2niix-install]
 * [Install dcm2bids][dcm2bids-install]
 * [Follow the tutorial][dcm2bids-tutorial]
 * [Seek for more advanced usage][dcm2bids-advanced]
@@ -44,11 +43,10 @@ Please take a look at the [documentation][dcm2bids-doc] to:
 
 We work hard to make sure `dcm2bids` is robust and we welcome comments and questions to make sure it meets your use case! Here's our preferred workflow:
 
-- If you have a usage question, we encourage you to post your question on [Neurostars][neurostars] with [dcm2bids][neurostars-dcm2bids] as an optional tag. The tag is really important because [Neurostars][neurostars-dcm2bids] will notify the `dcm2bids` team only if the tag is present. [Neurostars][neurostars-dcm2bids] is a question and answer forum for neuroscience researchers, infrastructure providers and software developers and free to access.
-  
-  Before posting your question, you may want to first browse through questions that were tagged with the [dcm2bids tag][neurostars-dcm2bids]. If your question persists, feel free to comment on previous questions or ask your own question.
+- If you have a usage question :raising_hand:, we encourage you to post your question on [Neurostars][neurostars] with [dcm2bids][neurostars-dcm2bids] as an optional tag. The tag is really important because [Neurostars][neurostars-dcm2bids] will notify the `dcm2bids` team only if the tag is present. [Neurostars][neurostars-dcm2bids] is a question and answer forum for neuroscience researchers, infrastructure providers and software developers, and free to access.  
+Before posting your question, you may want to first browse through questions that were tagged with the [dcm2bids tag][neurostars-dcm2bids]. If your question persists, feel free to comment on previous questions or ask your own question.
 
-- If you think you've found a bug, please open an issue on [our repository][dcm2bids-issues]. To do this, you'll need a GitHub account. See our [contributing guide](/CONTRIBUTING) for more details.
+- If you think you've found a bug :bug:, please open an issue on [our repository][dcm2bids-issues]. To do this, you'll need a GitHub account. See our [contributing guide](CONTRIBUTING/#open-an-issue-or-choose-one-to-fix) for more details.
 
 
 [bids]: http://bids.neuroimaging.io/

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 # dcm2bids
 Your friendly DICOM converter.
 
-[![Documentation](https://img.shields.io/badge/Documentation-dcm2bids-succes.svg)](https://unfmontreal.github.io/Dcm2Bids)
+[![Documentation badge](https://img.shields.io/badge/Documentation-dcm2bids-succes.svg)](https://unfmontreal.github.io/Dcm2Bids)
 [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.2616548.svg)](https://zenodo.org/badge/latestdoi/59581295)
-[![Anaconda-Server Badge](https://anaconda.org/conda-forge/dcm2bids/badges/latest_release_date.svg)](https://anaconda.org/conda-forge/dcm2bids)
+[![Last update badge](https://anaconda.org/conda-forge/dcm2bids/badges/latest_release_date.svg)](https://anaconda.org/conda-forge/dcm2bids)
 
 
-[![](https://github.com/unfmontreal/Dcm2Bids/workflows/Tests/badge.svg)](https://github.com/unfmontreal/Dcm2Bids/actionsk)
-[![](https://codecov.io/gh/unfmontreal/Dcm2Bids/branch/master/graph/badge.svg)](https://codecov.io/gh/unfmontreal/Dcm2Bids)
+[![Test status badge](https://github.com/unfmontreal/Dcm2Bids/workflows/Tests/badge.svg)](https://github.com/unfmontreal/Dcm2Bids/actionsk)
+[![Code coverage badge](https://codecov.io/gh/unfmontreal/Dcm2Bids/branch/master/graph/badge.svg)](https://codecov.io/gh/unfmontreal/Dcm2Bids)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 
-[![PyPI version](https://img.shields.io/pypi/v/dcm2bids)](https://pypi.org/project/dcm2bids)
-[![Anaconda-Server Badge](https://anaconda.org/conda-forge/dcm2bids/badges/version.svg)](https://anaconda.org/conda-forge/dcm2bids)
-[![Docker container](https://badgen.net/docker/pulls/unfmontreal/dcm2bids?icon=docker&label=pulls)](https://hub.docker.com/r/unfmontreal/dcm2bids)
+[![PyPI version badge](https://img.shields.io/pypi/v/dcm2bids?logo=pypi&logoColor=white)](https://pypi.org/project/dcm2bids)
+[![Anaconda-Server Badge](https://img.shields.io/conda/vn/conda-forge/dcm2bids?logo=anaconda&logoColor=white)](https://anaconda.org/conda-forge/dcm2bids)
+[![Docker container badge](https://img.shields.io/docker/v/unfmontreal/dcm2bids?label=docker&logo=docker&logoColor=white)](https://hub.docker.com/r/unfmontreal/dcm2bids)
 
 
-[![](https://img.shields.io/pypi/l/dcm2bids)](/docs/LICENSE.txt)
+[![License badge](https://img.shields.io/pypi/l/dcm2bids)](/docs/LICENSE.txt)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -40,24 +40,27 @@ Please take a look at the [documentation][dcm2bids-doc] to:
 * [Follow the tutorial][dcm2bids-tutorial]
 * [Seek for more advanced usage][dcm2bids-advanced]
 
-## Issues
+## Issues and Questions
 
 We work hard to make sure `dcm2bids` is robust and we welcome comments and questions to make sure it meets your use case! Here's our preferred workflow:
 
-- If you have a usage question, please post your issue on Neurostars with `dcm2bids` as an optional tag. The tag is really important because Neurostars will only notify us if the tag is present.
+- If you have a usage question, we encourage you to post your question on [Neurostars][neurostars] with [dcm2bids][neurostars-dcm2bids] as an optional tag. The tag is really important because [Neurostars][neurostars-dcm2bids] will notify the `dcm2bids` team only if the tag is present. [Neurostars][neurostars-dcm2bids] is a question and answer forum for neuroscience researchers, infrastructure providers and software developers and free to access.
+  
+  Before posting your question, you may want to first browse through questions that were tagged with the [dcm2bids tag][neurostars-dcm2bids]. If your question persists, feel free to comment on previous questions or ask your own question.
 
-- If you think you've found a bug, please open an issue here. To do this, you'll need a GitHub account. See our [contributing guide][dcm2bids-contributing] for more details.
+- If you think you've found a bug, please open an issue on [our repository][dcm2bids-issues]. To do this, you'll need a GitHub account. See our [contributing guide](/CONTRIBUTING) for more details.
 
 
 [bids]: http://bids.neuroimaging.io/
 [bids-examples]: https://github.com/bids-standard/bids-examples
 [bids-spec]: https://bids-specification.readthedocs.io/en/stable/
 [dcm2bids-doc]: https://unfmontreal.github.io/Dcm2Bids
-[dcm2bids-install]: https://unfmontreal.github.io/Dcm2Bids/#install
-[dcm2bids-tutorial]: https://unfmontreal.github.io/Dcm2Bids/tutorial
-[dcm2bids-advanced]: https://unfmontreal.github.io/Dcm2Bids/advance/
+[dcm2bids-install]: https://unfmontreal.github.io/Dcm2Bids/docs/2-tutorial/#setup
+[dcm2bids-tutorial]: https://unfmontreal.github.io/Dcm2Bids/2-tutorial
+[dcm2bids-advanced]: https://unfmontreal.github.io/Dcm2Bids/4-advance/
 [dcm2bids-issues]: https://github.com/UNFmontreal/Dcm2Bids/issues
 [dcm2niix-install]: https://github.com/rordenlab/dcm2niix#install
 [dcm2niix-github]: https://github.com/rordenlab/dcm2niix
 [neurostars]: https://neurostars.org/
-[dcm2bids-contributing]: https://unfmontreal.github.io/Dcm2Bids/CONTRIBUTING.md
+[neurostars-dcm2bids]: https://neurostars.org/tag/dcm2bids
+[dcm2bids-contributing]:  https://unfmontreal.github.io/Dcm2Bids/CONTRIBUTING

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Your friendly DICOM converter.
 [![Docker container](https://badgen.net/docker/pulls/unfmontreal/dcm2bids?icon=docker&label=pulls)](https://hub.docker.com/r/unfmontreal/dcm2bids)
 
 
-[![](https://img.shields.io/pypi/l/dcm2bids)](LICENSE.txt)
+[![](https://img.shields.io/pypi/l/dcm2bids)](/docs/LICENSE.txt)
 
 ---
 

--- a/docs/1-usage.md
+++ b/docs/1-usage.md
@@ -6,25 +6,29 @@ dcm2bids converts one session at a time. A session is all the acquisitions betwe
 
 You need to build a configuration file of your study to let dcm2bids associates your acquisitions through BIDS sidecar. Every study is different and this step needs a little bit of work. The scanner parameters should not change too much for one study (several MRI sessions), so a few configuration files should work.
 
-BIDS sidecar<sup>1</sup> files are `JSON` files with meta informations about the acquisition. `dcm2niix` (DICOM to NIfTI converter used by dcm2bids) creates automatically one BIDS sidecar for each NIfTI file.
+BIDS sidecar[^1] files are `JSON` files with meta informations about the acquisition. `dcm2niix` (DICOM to NIfTI converter used by dcm2bids) creates automatically one BIDS sidecar for each NIfTI file.
 
 dcm2bids configuration file uses also the `JSON` format. One example is provided in the `example` folder on the github repository.
 
 It is recommended to use an editor with syntax highlighting to build a correct JSON file. Here is an [online][json-editor] one.
 
-## CLI
+## Command Line Interface (CLI)
 
 How to launch dcm2bids when you have build your configuration file ? First `cd` in your BIDS directory.
 
-`dcm2bids -d DICOM_DIR -p PARTICIPANT_ID -c CONFIG_FILE`
+```bash
+dcm2bids -d DICOM_DIR -p PARTICIPANT_ID -c CONFIG_FILE
+```
 
 If your participant have a session ID:
 
-`dcm2bids -d DICOM_DIR -p PARTICIPANT_ID -s SESSION_ID -c CONFIG_FILE`
+```bash
+dcm2bids -d DICOM_DIR -p PARTICIPANT_ID -s SESSION_ID -c CONFIG_FILE
+```
 
 dcm2bids creates log files inside `tmp_dcm2bids/log`
 
-See `dcm2bids -h` for more informations
+See `dcm2bids -h` or `dcm2bids --help` to show the help message that contains more information.
 
 ## Output
 
@@ -40,13 +44,17 @@ Sidecars with no or more than one matching descriptions are kept in `tmp_dcm2bid
 
 - Helper
 
-`dcm2bids_helper -d DICOM_DIR [-o OUTPUT_DIR]`
+```bash
+dcm2bids_helper -d DICOM_DIR [-o OUTPUT_DIR]
+```
 
 To build the configuration file, you need to have a example of the sidecars. You can use `dcm2bids_helper` with the DICOMs of one participant. It will launch dcm2niix and save the result inside the `tmp_dcm2bids/helper` of the output directory.
 
 - Scaffold
 
-`dcm2bids_scaffold [-o OUTPUT_DIR]`
+```bash
+dcm2bids_scaffold [-o OUTPUT_DIR]
+```
 
 Create basic BIDS files and directories in the output directory (by default folder where the script is launched).
 
@@ -57,13 +65,20 @@ Create basic BIDS files and directories in the output directory (by default fold
 
 You can also use all the tools through docker or singularity images.
 
-## Docker
-Download the latest release of the Docker container for dcm2bids:
+=== "Docker"
+    ```console
+    docker pull unfmontreal/dcm2bids:latest
+    ```
 
-`docker pull unfmontreal/dcm2bids:latest`
+=== "Singularity"
+    ```console
+    singularity pull dcm2bids_latest.sif docker://unfmontreal/dcm2bids:latest
+    ```
+   
+[^1]: For each acquisition, `dcm2niix` creates an associated `.json` file,
+    containing information from the dicom header. These are known as
+    __sidecars__. These are the sidecars `dcm2bids` uses to filter the groups
+    of acquisitions.
 
-## Singularity
-
-Build the latest singularity image:
-
-`singularity build dcm2bids.sif containers/singularity.def`
+    To define this filtering you will probably need to review these sidecars.
+    You can generate all the sidecars for an individual participant using [dcm2bids_helper](1-usage.md#tools).

--- a/docs/2-tutorial.md
+++ b/docs/2-tutorial.md
@@ -23,6 +23,7 @@ channels:
     - conda-forge
 dependencies:
     - dcm2niix
+    - dcm2bids
     - pip
 ```
 
@@ -34,7 +35,7 @@ source activate dcm2bids
 pip install dcm2bids
 ```
 
-We should have access to dcm2bids now. Test it with `dcm2bids --help`.
+We should have access to `dcm2bids` now. Test it with `dcm2bids --help`.
 
 ## Scaffolding
 
@@ -97,7 +98,7 @@ In this case we could add another criteria to match the acquisition by the filen
 
 With all this information we could then update our configuration file.
 
-```
+```json hl_lines="9"
 {
     "descriptions": [
         {
@@ -117,7 +118,7 @@ For the two fieldmaps, we can see that with patterns of `"*EPI_PE=AP*"` or `"*EP
 
 We could then update our configuration file.
 
-```
+```json hl_lines="17 26"
 {
     "descriptions": [
         {
@@ -151,18 +152,20 @@ We could then update our configuration file.
 }
 ```
 
-For fieldmap, we added an `"intendedFor"` field to show that these fieldmaps should be use with our fMRI acquisition. Have a look at the explanation of [intendedFor](../config/#intendedfor) in the documentation or in the [BIDS specification][bids-fmap].
+For fieldmap, we added an `"intendedFor"` field to show that these fieldmaps should be use with our fMRI acquisition. Have a look at the explanation of [intendedFor](/docs/3-configuration/#intendedfor) in the documentation or in the [BIDS specification][bids-fmap].
 
 ## Running dcm2bids
 
 We can now run dcm2bids:
 
-`dcm2bids -d sourcedata/dcm_qa_nih-master/In/ -p ID01 -c code/dcm2bids_config.json`
+```bash
+dcm2bids -d sourcedata/dcm_qa_nih-master/In/ -p ID01 -c code/dcm2bids_config.json
+```
 
 A bunch of information is print to the terminal and we can verify that the data are now in BIDS.
 
-```bash
-$ ls sub-ID01/*
+```console
+user@pc:data/$ ls sub-ID01/*
 sub-ID01/fmap:
 sub-ID01_dir-AP_epi.json  sub-ID01_dir-AP_epi.nii.gz
 sub-ID01_dir-PA_epi.json  sub-ID01_dir-PA_epi.nii.gz

--- a/docs/3-configuration.md
+++ b/docs/3-configuration.md
@@ -48,11 +48,11 @@ Each description tells dcm2bids how to group a set of acquisitions and how to la
 }
 ```
 
-in their sidecars<sup>1</sup> and label them as `anat`, `T2w` type images.
+in their sidecars[^1] and label them as `anat`, `T2w` type images.
 
 ## criteria
 
-dcm2bids will try to match the sidecars<sup>1</sup> of dcm2niix to the descriptions of the configuration file. The values you enter inside the criteria dictionary are patterns that will be compared to the corresponding key of the sidecar.
+dcm2bids will try to match the sidecars[^1] of dcm2niix to the descriptions of the configuration file. The values you enter inside the criteria dictionary are patterns that will be compared to the corresponding key of the sidecar.
 
 The pattern matching is shell-style. It's possible to use wildcard `*`, single character `?` etc ... Please have a look at the [GNU documentation][gnu-pattern] to know more.
 
@@ -86,15 +86,32 @@ Optional field to change or add information in a sidecar.
 
 ## intendedFor
 
-Optional field to add an `IntendedFor` entry in the sidecar of a fieldmap. Just put the index or a list of index of the description(s) that's intended for.
+Optional[^2] field to add an `IntendedFor` entry in the sidecar of a fieldmap. Just put the index or a list of index of the description(s) that's intended for.
 
-Python index begins at `0` so in the example, `0` means it is intended for `task-rest_bold`.
+Python index begins at `0` so in the example, `0` means[^3] it is intended for `task-rest_bold`.
 
-#### <sup>1</sup>: sidecars
+[^1]: For each acquisition, `dcm2niix` creates an associated `.json` file,
+    containing information from the dicom header. These are known as
+    __sidecars__. These are the sidecars `dcm2bids` uses to filter the groups
+    of acquisitions.
 
-For each acquisition, __dcm2niix__ creates an associated .json file, containing information from the dicom header. These are known as __sidecars__. These are the sidecars __dcm2bids__ uses to filter the groups of acquisitions.
+    To define this filtering you will probably need to review these sidecars.
+    You can generate all the sidecars for an individual participant using [dcm2bids_helper](1-usage.md#tools).
 
-To define this filtering you will probably need to review these sidecars. You can generate all the sidecars for an individual participant using [dcm2bids_helper](1-usage.md#tools).
+[^2]: For each acquisition, `dcm2niix` creates an associated `.json` file,
+    containing information from the dicom header. These are known as
+    __sidecars__. These are the sidecars `dcm2bids` uses to filter the groups
+    of acquisitions.
 
+    To define this filtering you will probably need to review these sidecars.
+    You can generate all the sidecars for an individual participant using [dcm2bids_helper](1-usage.md#tools).
+
+[^3]: For each acquisition, `dcm2niix` creates an associated `.json` file,
+    containing information from the dicom header. These are known as
+    __sidecars__. These are the sidecars `dcm2bids` uses to filter the groups
+    of acquisitions.
+
+    To define this filtering you will probably need to review these sidecars.
+    You can generate all the sidecars for an individual participant using [dcm2bids_helper](1-usage.md#tools).
 [bids-spec]: https://bids-specification.readthedocs.io/en/stable/
 [gnu-pattern]: https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html

--- a/docs/3-configuration.md
+++ b/docs/3-configuration.md
@@ -86,9 +86,9 @@ Optional field to change or add information in a sidecar.
 
 ## intendedFor
 
-Optional[^2] field to add an `IntendedFor` entry in the sidecar of a fieldmap. Just put the index or a list of index of the description(s) that's intended for.
+Optional field to add an `IntendedFor` entry in the sidecar of a fieldmap. Just put the index or a list of index of the description(s) that's intended for.
 
-Python index begins at `0` so in the example, `0` means[^3] it is intended for `task-rest_bold`.
+Python index begins at `0` so in the example, `0` means it is intended for `task-rest_bold`.
 
 [^1]: For each acquisition, `dcm2niix` creates an associated `.json` file,
     containing information from the dicom header. These are known as
@@ -98,20 +98,5 @@ Python index begins at `0` so in the example, `0` means[^3] it is intended for `
     To define this filtering you will probably need to review these sidecars.
     You can generate all the sidecars for an individual participant using [dcm2bids_helper](1-usage.md#tools).
 
-[^2]: For each acquisition, `dcm2niix` creates an associated `.json` file,
-    containing information from the dicom header. These are known as
-    __sidecars__. These are the sidecars `dcm2bids` uses to filter the groups
-    of acquisitions.
-
-    To define this filtering you will probably need to review these sidecars.
-    You can generate all the sidecars for an individual participant using [dcm2bids_helper](1-usage.md#tools).
-
-[^3]: For each acquisition, `dcm2niix` creates an associated `.json` file,
-    containing information from the dicom header. These are known as
-    __sidecars__. These are the sidecars `dcm2bids` uses to filter the groups
-    of acquisitions.
-
-    To define this filtering you will probably need to review these sidecars.
-    You can generate all the sidecars for an individual participant using [dcm2bids_helper](1-usage.md#tools).
 [bids-spec]: https://bids-specification.readthedocs.io/en/stable/
 [gnu-pattern]: https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html

--- a/docs/4-advance.md
+++ b/docs/4-advance.md
@@ -30,7 +30,8 @@ It's only disabled when used with `"searchMethod": "fnmatch"`.
 
 default: `"defaceTpl": None`
 
-The anonymizer option no longer exists from `v2.0.0`. It is still possible to deface the anatomical nifti images.
+!!! danger
+    The anonymizer option no longer exists from `v2.0.0`. It is still possible to deface the anatomical nifti images.
 
 For example, if you use the last version of pydeface, add:
 

--- a/docs/LICENSE.txt
+++ b/docs/LICENSE.txt
@@ -1,0 +1,678 @@
+dcm2bids Copyright (C) 2017 Christophe Bedetti
+
+Text of GPLv3 License:
+======================
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    {one line to give the program's name and a brief idea of what it does.}
+    Copyright (C) {year}  {name of author}
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    {project}  Copyright (C) {year}  {fullname}
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,19 @@
+:root {
+  --md-primary-fg-color:               hsla(16, 100%, 42%, 1);
+  --md-primary-fg-color--light:        hsla(16, 100%, 64%, 1);
+  --md-primary-fg-color--dark:         hsla(16, 100%, 28%, 1);
+
+  --md-accent-fg-color:                hsla(196, 100%, 44%, 1);
+  --md-accent-fg-color--transparent:   hsla(196, 100%, 44%, 0.1);
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: var(--md-footer-bg-color--dark);
+  --md-primary-bg-color: hsla(16, 100%, 42%, 1);
+  --md-hue:              213;
+}
+
+.md-search-result__meta {
+  /* background-color: var(--md-default-fg-color); */
+  color: var(--md-typeset-color);
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,14 +25,12 @@ extra_css = ["docs/stylesheets/extra.css"] # To fix some colors in light vs slat
 # Add a bunch of markdown extensions to improve the documentation (and the look ;)).
 # See https://squidfunk.github.io/mkdocs-material/reference/abbreviations/
 # for full list of extensions.
-markdown_extensions = ["toc",
-                       "admonition",
+markdown_extensions = ["admonition",
                        "footnotes",
                        "pymdownx.emoji",
                        "pymdownx.caret",
                        "pymdownx.mark",
                        "pymdownx.tilde",
-                       "pymdownx.highlight",
                        "pymdownx.details",
                        "pymdownx.superfences",
                        "pymdownx.tabbed"]
@@ -72,6 +70,11 @@ permalink = "⚓︎"
 [[tool.portray.mkdocs.markdown_extensions]]
 [tool.portray.mkdocs.markdown_extensions."pymdownx.highlight"]
 linenums = true # Always add line numbers in code blocks
+
+[[tool.portray.mkdocs.markdown_extensions]]
+[tool.portray.mkdocs.markdown_extensions."pymdownx.tasklist"]
+custom_checkbox = true
+clickable_checkbox = false
 
 # [[tool.portray.mkdocs.plugins]]
 # [tool.portray.mkdocs.plugins.git-revision-date]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,22 +2,15 @@
 modules = ["dcm2bids"]
 # docs_dir = ["docs"]
 # extra_dirs = ["media", "art"]
-# extra_markdown_extensions:
 
 [tool.portray.mkdocs]
-extra_css = ["docs/stylesheets/extra.css"]
-markdown_extensions = ["toc", "admonition", "footnotes", "pymdownx.emoji", "pymdownx.caret", "pymdownx.mark", "pymdownx.tilde", "pymdownx.highlight", "pymdownx.superfences"]
 # Repository
-repo_name = "UNFmontreal/dcm2bids"
+repo_name = "UNFmontreal/dcm2bids" # Name in top right corner
+# Set repo_url so anyone running from their own repo can see from true dcm2bids repo.
 repo_url = "https://github.com/UNFmontreal/Dcm2Bids"
-edit_uri = "blob/master/"
+edit_uri = "blob/master/" # Bring to the page on GH, but it won't open the _edit_ mode.
 
-# a list of mappings of {LABEL: FILENAME or LIST_OF_MAPPING} but not a mix of
-# both. This still allows as much customization as is permitted by mkdocs 
-# just with more consistency enforced.
-
-# plugins = ["git-revision-date-localized"] 
-
+# Left navigation menu
 nav = [{  Home = "README.md"},
        {  "Code of conduct" = "CODE_OF_CONDUCT.md" },
        {  "Contributing" = "CONTRIBUTING.md"},
@@ -27,16 +20,30 @@ nav = [{  Home = "README.md"},
        {  "4. Advance" = "docs/4-advance.md"},
        {  "Changelog" = "CHANGELOG.md"}]
 
+extra_css = ["docs/stylesheets/extra.css"] # To fix some colors in light vs slate mode.
+
+# Add a bunch of markdown extensions to improve the documentation (and the look ;)).
+# See https://squidfunk.github.io/mkdocs-material/reference/abbreviations/
+# for full list of extensions.
+markdown_extensions = ["toc",
+                       "admonition",
+                       "footnotes",
+                       "pymdownx.emoji",
+                       "pymdownx.caret",
+                       "pymdownx.mark",
+                       "pymdownx.tilde",
+                       "pymdownx.highlight",
+                       "pymdownx.details",
+                       "pymdownx.superfences",
+                       "pymdownx.tabbed"]
+
+# TODO: Implement plugin so git info is displayed on each page,
+# issue has been open on portray to fix the bug.
+# plugins = ["git-revision-date", "git-revision-date-localized", "bibtext"]
+
 [tool.portray.mkdocs.theme]
 name = "material"
-icon = {repo = "fontawesome/brands/github"}
-# favicon = "art/logo_small.png"
-# logo = "art/logo_small.png"
-
-
-
-# palette = {scheme = "preference"}
-
+# Blurb that is output when the doc site is shared on social media or elsewhere.
 site_description = """
   This is the documentation for dcm2bids, a community-centered project
   that aims to be an easy-to-use tool to automate the process of 1- converting
@@ -44,20 +51,39 @@ site_description = """
   Imaging Data Structure (BIDS).
   """
 
-# Additional settings for plugins
+# Design related stuff
 
+icon = {repo = "fontawesome/brands/github"} # icon in top-right corner.
+# TODO: Design a logo and/or favicon.
+# favicon = "art/logo_small.png"
+# logo = "art/logo_small.png"
+
+palette = {scheme = "preference"}
+# Alternative way of setting multiple option for the palette
+# [[tool.portray.mkdocs.theme.palette]]
+# scheme = "preference"
+
+
+# Additional settings for plugins
 [[tool.portray.mkdocs.markdown_extensions]]
 [tool.portray.mkdocs.markdown_extensions.toc]
-permalink = true
+permalink = "⚓︎"
 
-# [[tool.portray.mkdocs.markdown_extensions]]
-# [tool.portray.mkdocs.markdown_extensions."pymdownx.highlight"]
-# linenums = true
+[[tool.portray.mkdocs.markdown_extensions]]
+[tool.portray.mkdocs.markdown_extensions."pymdownx.highlight"]
+linenums = true # Always add line numbers in code blocks
 
-[[tool.portray.mkdocs.theme.palette]]
-scheme = "preference"
+# [[tool.portray.mkdocs.plugins]]
+# [tool.portray.mkdocs.plugins.git-revision-date]
+# enabled_if_env = "CI"
+
+# [[tool.portray.mkdocs.plugins]]
+# [tool.portray.mkdocs.plugins.git-revision-date-localized]
+# type = "date"
+# fallback_to_build_date = true
 
 
+## Footer icon in bottom-right corner
 [[tool.portray.mkdocs.extra.social]]
 icon = "fontawesome/brands/github"
 link = "https://github.com/UNFmontreal/Dcm2Bids"
@@ -67,29 +93,4 @@ name = "dcm2bids on GitHub"
 icon = "fontawesome/brands/docker"
 link = "https://hub.docker.com/r/unfmontreal/dcm2bids"
 name = "dcm2bids on docker"
-
-# [[tool.portray.mkdocs.nav]]
-# Home = "README.md"
-
-# [[tool.portray.mkdocs.nav]]
-# "Code of conduct" = "CODE_OF_CONDUCT.md"
-
-# [[tool.portray.mkdocs.nav]]
-# "Contributing" = "CONTRIBUTING.md"
-
-# [[tool.portray.mkdocs.nav]]
-# "1. Usage" = "docs/1-usage.md"
-
-# [[tool.portray.mkdocs.nav]]
-# "2. Tutorial" = "docs/2-tutorial.md"
-
-# [[tool.portray.mkdocs.nav]]
-# "3. Configuration" = "docs/3-configuration.md"
-
-# [[tool.portray.mkdocs.nav]]
-# "4. Advance" = "docs/4-advance.md"
-
-# [[tool.portray.mkdocs.nav]]
-# "Changelog" = "CHANGELOG.md"
-
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,30 +1,95 @@
 [tool.portray]
 modules = ["dcm2bids"]
+# docs_dir = ["docs"]
+# extra_dirs = ["media", "art"]
+# extra_markdown_extensions:
+
+[tool.portray.mkdocs]
+extra_css = ["docs/stylesheets/extra.css"]
+markdown_extensions = ["toc", "admonition", "footnotes", "pymdownx.emoji", "pymdownx.caret", "pymdownx.mark", "pymdownx.tilde", "pymdownx.highlight", "pymdownx.superfences"]
+# Repository
+repo_name = "UNFmontreal/dcm2bids"
+repo_url = "https://github.com/UNFmontreal/Dcm2Bids"
+edit_uri = "blob/master/"
+
+# a list of mappings of {LABEL: FILENAME or LIST_OF_MAPPING} but not a mix of
+# both. This still allows as much customization as is permitted by mkdocs 
+# just with more consistency enforced.
+
+# plugins = ["git-revision-date-localized"] 
+
+nav = [{  Home = "README.md"},
+       {  "Code of conduct" = "CODE_OF_CONDUCT.md" },
+       {  "Contributing" = "CONTRIBUTING.md"},
+       {  "1. Usage" = "docs/1-usage.md"},
+       {  "2. Tutorial" = "docs/2-tutorial.md"},
+       {  "3. Configuration" = "docs/3-configuration.md"},
+       {  "4. Advance" = "docs/4-advance.md"},
+       {  "Changelog" = "CHANGELOG.md"}]
 
 [tool.portray.mkdocs.theme]
 name = "material"
-palette = {primary = "deep-orange"}
+icon = {repo = "fontawesome/brands/github"}
+# favicon = "art/logo_small.png"
+# logo = "art/logo_small.png"
 
-[[tool.portray.mkdocs.nav]]
-Home = "README.md"
 
-[[tool.portray.mkdocs.nav]]
-"Code of conduct" = "CODE_OF_CONDUCT.md"
 
-[[tool.portray.mkdocs.nav]]
-"Contributing" = "CONTRIBUTING.md"
+# palette = {scheme = "preference"}
 
-[[tool.portray.mkdocs.nav]]
-"1. Usage" = "docs/1-usage.md"
+site_description = """
+  This is the documentation for dcm2bids, a community-centered project
+  that aims to be an easy-to-use tool to automate the process of 1- converting
+  DICOM files to NIfTI files with dcm2niix and 2- reorganising NIfTI files into the Brain
+  Imaging Data Structure (BIDS).
+  """
 
-[[tool.portray.mkdocs.nav]]
-"2. Tutorial" = "docs/2-tutorial.md"
+# Additional settings for plugins
 
-[[tool.portray.mkdocs.nav]]
-"3. Configuration" = "docs/3-configuration.md"
+[[tool.portray.mkdocs.markdown_extensions]]
+[tool.portray.mkdocs.markdown_extensions.toc]
+permalink = true
 
-[[tool.portray.mkdocs.nav]]
-"4. Advance" = "docs/4-advance.md"
+# [[tool.portray.mkdocs.markdown_extensions]]
+# [tool.portray.mkdocs.markdown_extensions."pymdownx.highlight"]
+# linenums = true
 
-[[tool.portray.mkdocs.nav]]
-"Changelog" = "CHANGELOG.md"
+[[tool.portray.mkdocs.theme.palette]]
+scheme = "preference"
+
+
+[[tool.portray.mkdocs.extra.social]]
+icon = "fontawesome/brands/github"
+link = "https://github.com/UNFmontreal/Dcm2Bids"
+name = "dcm2bids on GitHub"
+
+[[tool.portray.mkdocs.extra.social]]
+icon = "fontawesome/brands/docker"
+link = "https://hub.docker.com/r/unfmontreal/dcm2bids"
+name = "dcm2bids on docker"
+
+# [[tool.portray.mkdocs.nav]]
+# Home = "README.md"
+
+# [[tool.portray.mkdocs.nav]]
+# "Code of conduct" = "CODE_OF_CONDUCT.md"
+
+# [[tool.portray.mkdocs.nav]]
+# "Contributing" = "CONTRIBUTING.md"
+
+# [[tool.portray.mkdocs.nav]]
+# "1. Usage" = "docs/1-usage.md"
+
+# [[tool.portray.mkdocs.nav]]
+# "2. Tutorial" = "docs/2-tutorial.md"
+
+# [[tool.portray.mkdocs.nav]]
+# "3. Configuration" = "docs/3-configuration.md"
+
+# [[tool.portray.mkdocs.nav]]
+# "4. Advance" = "docs/4-advance.md"
+
+# [[tool.portray.mkdocs.nav]]
+# "Changelog" = "CHANGELOG.md"
+
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 ipython>=7.10.0
 portray>=1.3.1
 tox>=3.14.0
+dcm2bids


### PR DESCRIPTION
Now that dcm2bids is on [conda-forge](https://anaconda.org/conda-forge/dcm2bids) (#119), I added main badges relevant to Conda on the README.md file + docker and changed the formatting from HTML to markdown for all badges.