### PR TITLE
[BUG, ENH] - fix erroneous install command

### DIFF
--- a/docs/2-tutorial.md
+++ b/docs/2-tutorial.md
@@ -32,7 +32,6 @@ Finaly, create a new conda environment to install dcm2bids:
 ```bash
 conda env create -f environment.yml
 source activate dcm2bids
-pip install dcm2bids
 ```
 
 We should have access to `dcm2bids` now. Test it with `dcm2bids --help`.


### PR DESCRIPTION
I deleted the `pip install dcm2bids` command since conda now takes care of it in the tutorial. (re #120)