### PR TITLE
Allow intendedFor to reference description IDs

### DIFF
--- a/dcm2bids/structure.py
+++ b/dcm2bids/structure.py
@@ -227,7 +227,13 @@ class Acquisition(object):
         if self.intendedFor != [None]:
             intendedValue = []
             for index in self.intendedFor:
-                intendedDesc = descriptions[index]
+                if isinstance(index, str):
+                    matches = [d for d in descriptions if d.get('id') == index]
+                    if len(matches) == 0:
+                        raise ValueError(f'No description with id [{index}]')
+                    intendedDesc = matches[0]
+                else:
+                    intendedDesc = descriptions[index]
 
                 session = self.participant.session
                 dataType = intendedDesc["dataType"]


### PR DESCRIPTION
Curious if allowing something like this would be desirable: I added a small step to the `Acquisition.dstSidecarData` method to check if the current `intendedFor` field is a string, if it is then it looks through the descriptions for one (or more) with a matching `id` field.

This would allow a user to (**optionally**) insert `id` fields in the descriptions and reference those descriptions with that name. Something like:

```diff
# file: example/config.json - truncated
{
    "searchMethod": "fnmatch",
    "defaceTpl": "pydeface --outfile {dstFile} {srcFile}",
    "descriptions": [
        {
            "dataType": "anat",
            "modalityLabel": "T1w",
            "criteria": {
                "SeriesDescription": "*T1W_3D*"
            }
        },
        ...
        {
+           "id": "my-swi-scan",
            "dataType": "anat",
            "modalityLabel": "SWI",
            "criteria": {
                "SeriesDescription": "*SWI*"
            }
        },
        {
            "dataType": "func",
            "modalityLabel": "bold",
            "customLabels": "task-rest",
            "criteria": {
                "SeriesDescription": "rs_fMRI"
            },
            "sidecarChanges": {
                "SeriesDescription": "rsfMRI"
            }
        },
        {
            "dataType": "fmap",
            "modalityLabel": "fmap",
            "criteria": {
                "SidecarFilename": "*echo-4*"
            },
-           "IntendedFor": 5
+           "IntendedFor": "my-swi-scan"
        }
    ]
}
```

While the current indexing scheme works, I've found it to be a little brittle, reorganizing the descriptions means having to update the `intendedFor` indices, also I've been tracking config files in git, and it's not too hard for the indices to potentially get out of whack with multiple people contributing to a config file.

This could be a slightly more stable alternative.

If this is of interest I can add tests and update the docs accordingly.