### PR TITLE
WIP: Add Argument for Configuring dcm2niix Search Depth

### DIFF
--- a/dcm2bids/dcm2bids.py
+++ b/dcm2bids/dcm2bids.py
@@ -46,6 +46,7 @@ class Dcm2bids(object):
         session=DEFAULT.session,
         clobber=DEFAULT.clobber,
         forceDcm2niix=DEFAULT.forceDcm2niix,
+        search_depth=DEFAULT.search_depth,
         log_level=DEFAULT.logLevel,
         **_
     ):
@@ -57,6 +58,7 @@ class Dcm2bids(object):
         self.participant = Participant(participant, session)
         self.clobber = clobber
         self.forceDcm2niix = forceDcm2niix
+        self.search_depth = search_depth
         self.logLevel = log_level
 
         # logging setup
@@ -102,6 +104,7 @@ class Dcm2bids(object):
             self.bidsDir,
             self.participant,
             self.config.get("dcm2niixOptions", DEFAULT.dcm2niixOptions),
+            self.search_depth
         )
 
         check_latest()
@@ -225,6 +228,10 @@ def _build_arg_parser():
                    action="store_true",
                    help="Overwrite previous temporary dcm2niix "
                         "output if it exists.")
+
+    p.add_argument("--search_depth",
+                   default=DEFAULT.search_depth,
+                   help="Directory search depth. (Defaults to %(default)s). Valid ranges: 0-9")
 
     p.add_argument("--clobber",
                    action="store_true",

--- a/dcm2bids/dcm2niix.py
+++ b/dcm2bids/dcm2niix.py
@@ -25,7 +25,7 @@ class Dcm2niix(object):
     """
 
     def __init__(
-        self, dicomDirs, bidsDir, participant=None, options=DEFAULT.dcm2niixOptions
+        self, dicomDirs, bidsDir, participant=None, options=DEFAULT.dcm2niixOptions, search_depth=DEFAULT.search_depth
     ):
         self.logger = logging.getLogger(__name__)
 
@@ -35,6 +35,13 @@ class Dcm2niix(object):
         self.bidsDir = bidsDir
         self.participant = participant
         self.options = options
+        self.search_depth = search_depth
+
+        self.logger.info("search depth: %s", self.search_depth)
+
+        # Add search depth to options if its different from the default.
+        if search_depth != DEFAULT.search_depth:
+            options += f" -d {search_depth}"
 
     @property
     def outputDir(self):
@@ -95,7 +102,7 @@ class Dcm2niix(object):
         """ Execute dcm2niix for each directory in dicomDirs
         """
         for dicomDir in self.dicomDirs:
-            cmd = ['dcm2niix', *shlex.split(self.options),
+            cmd = ['dcm2niix', *shlex.split(self.options), '-d' , self.search_depth,
                    '-o', self.outputDir, dicomDir]
             output = run_shell_command(cmd)
 

--- a/dcm2bids/utils.py
+++ b/dcm2bids/utils.py
@@ -25,6 +25,7 @@ class DEFAULT(object):
     session = ""  # also Participant object
     clobber = False
     forceDcm2niix = False
+    search_depth = 5
     defaceTpl = None
     logLevel = "WARNING"
 


### PR DESCRIPTION
Adds an additional argument, `--search_depth`, that allows the user to pass through a value to the `-d` argument in dcm2niix, which configures search depth.

A new DEFAULT field was added to provide a default search depth value that matches dcm2niix's default.