### PR TITLE
Move tmp directory

### DIFF
--- a/dcm2bids/dcm2niix.py
+++ b/dcm2bids/dcm2niix.py
@@ -44,7 +44,7 @@ class Dcm2niix(object):
         """
         tmpDir = self.participant.prefix if self.participant else DEFAULT.helperDir
 
-        return self.bidsDir / DEFAULT.tmpDirName / tmpDir
+        return os.getcwd() / DEFAULT.tmpDirName / tmpDir
 
     def run(self, force=False):
         """ Run dcm2niix if necessary


### PR DESCRIPTION
Proposing to move tmp directory to where one invokes dcm2bids (e.g., from `sourcedata`) instead of being placed in the BIDS root by default (which is not BIDS valid).