### PR TITLE
[FIX] Broken scaffold no more

### DIFF
--- a/dcm2bids/cli/dcm2bids_scaffold.py
+++ b/dcm2bids/cli/dcm2bids_scaffold.py
@@ -15,7 +15,6 @@ import logging
 import os
 import sys
 from os.path import join as opj
-from pathlib import Path
 from dcm2bids.utils.io import write_txt
 from dcm2bids.utils.args import add_overwrite_arg, assert_dirs_empty
 from dcm2bids.utils.utils import DEFAULT, run_shell_command, TreePrinter
@@ -48,14 +47,18 @@ def main():
     for _ in ["code", "derivatives", "sourcedata"]:
         os.makedirs(opj(args.output_dir, _), exist_ok=True)
 
-    logger.info("Currently running the following command: \n" + " ".join(sys.argv) + "\n")
+    logger.info("Currently running the following command: \n" +
+                " ".join(sys.argv) + "\n")
     logger.info("The files used to create your BIDS directory were taken from "
                 "https://github.com/bids-standard/bids-starter-kit. \n")
 
     # CHANGES
     write_txt(opj(args.output_dir, "CHANGES"),
               bids_starter_kit.CHANGES.replace('DATE',
-                                               datetime.date.today().strftime("%Y-%m-%d")))
+                                               datetime.date.today().strftime(
+                                                 "%Y-%m-%d")
+                                               )
+              )
     # dataset_description
     write_txt(opj(args.output_dir, "dataset_description"),
               bids_starter_kit.dataset_description.replace("BIDS_VERSION",
@@ -76,7 +79,8 @@ def main():
     # README
     try:
         run_shell_command(['wget', '-q', '-O', opj(args.output_dir, "README"),
-                           'https://raw.githubusercontent.com/bids-standard/bids-starter-kit/main/templates/README.MD'], log = False)
+                           'https://raw.githubusercontent.com/bids-standard/bids-starter-kit/main/templates/README.MD'],
+                          log=False)
     except Exception:
         write_txt(opj(args.output_dir, "README"),
                   bids_starter_kit.README)
@@ -84,6 +88,7 @@ def main():
     # output tree representation of where the scaffold was built.
 
     TreePrinter(args.output_dir).print_tree()
+
 
 if __name__ == "__main__":
     main()

--- a/dcm2bids/cli/dcm2bids_scaffold.py
+++ b/dcm2bids/cli/dcm2bids_scaffold.py
@@ -66,7 +66,7 @@ def main():
     # README
     try:
         run_shell_command(['wget', '-q', '-O', opj(args.output_dir, "README"),
-                           'https://github.com/bids-standard/bids-starter-kit/blob/main/templates/README.MD'])
+                           'https://raw.githubusercontent.com/bids-standard/bids-starter-kit/main/templates/README.MD'])
     except:
         write_txt(opj(args.output_dir, "README"),
                   bids_starter_kit.README)

--- a/dcm2bids/cli/dcm2bids_scaffold.py
+++ b/dcm2bids/cli/dcm2bids_scaffold.py
@@ -13,12 +13,14 @@ import argparse
 import datetime
 import logging
 import os
+import sys
 from os.path import join as opj
-
+from pathlib import Path
 from dcm2bids.utils.io import write_txt
 from dcm2bids.utils.args import add_overwrite_arg, assert_dirs_empty
-from dcm2bids.utils.utils import DEFAULT, run_shell_command
+from dcm2bids.utils.utils import DEFAULT, run_shell_command, TreePrinter
 from dcm2bids.utils.scaffold import bids_starter_kit
+from dcm2bids.utils.logger import setup_logging
 
 
 def _build_arg_parser():
@@ -38,18 +40,22 @@ def main():
     parser = _build_arg_parser()
     args = parser.parse_args()
 
+    setup_logging("info")
+    logger = logging.getLogger(__name__)
+
     assert_dirs_empty(parser, args, args.output_dir)
 
     for _ in ["code", "derivatives", "sourcedata"]:
         os.makedirs(opj(args.output_dir, _), exist_ok=True)
 
-    logging.info("The files used to create your BIDS directory comes from"
-                 "https://github.com/bids-standard/bids-starter-kit")
+    logger.info("Currently running the following command: \n" + " ".join(sys.argv) + "\n")
+    logger.info("The files used to create your BIDS directory were taken from "
+                "https://github.com/bids-standard/bids-starter-kit. \n")
+
     # CHANGES
     write_txt(opj(args.output_dir, "CHANGES"),
               bids_starter_kit.CHANGES.replace('DATE',
                                                datetime.date.today().strftime("%Y-%m-%d")))
-
     # dataset_description
     write_txt(opj(args.output_dir, "dataset_description"),
               bids_starter_kit.dataset_description.replace("BIDS_VERSION",
@@ -66,11 +72,14 @@ def main():
     # README
     try:
         run_shell_command(['wget', '-q', '-O', opj(args.output_dir, "README"),
-                           'https://raw.githubusercontent.com/bids-standard/bids-starter-kit/main/templates/README.MD'])
-    except:
+                           'https://raw.githubusercontent.com/bids-standard/bids-starter-kit/main/templates/README.MD'], log = False)
+    except Exception:
         write_txt(opj(args.output_dir, "README"),
                   bids_starter_kit.README)
 
+    # output tree representation of where the scaffold was built.
+
+    TreePrinter(args.output_dir).print_tree()
 
 if __name__ == "__main__":
     main()

--- a/dcm2bids/cli/dcm2bids_scaffold.py
+++ b/dcm2bids/cli/dcm2bids_scaffold.py
@@ -69,6 +69,10 @@ def main():
     write_txt(opj(args.output_dir, "participants.tsv"),
               bids_starter_kit.participants_tsv)
 
+    # .bidsignore
+    write_txt(opj(args.output_dir, ".bidsignore"),
+              "tmp_dcm2bids")
+
     # README
     try:
         run_shell_command(['wget', '-q', '-O', opj(args.output_dir, "README"),

--- a/dcm2bids/utils/io.py
+++ b/dcm2bids/utils/io.py
@@ -1,13 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import inspect
 import json
-import os
-import os.path as opj
 from pathlib import Path
 from collections import OrderedDict
-
-import dcm2bids
 
 
 def load_json(filename):
@@ -32,6 +27,7 @@ def save_json(filename, data):
 def write_txt(filename, lines):
     with open(filename, "w") as f:
         f.write(f"{lines}\n")
+
 
 def valid_path(in_path, type="folder"):
     """Assert that file exists.

--- a/dcm2bids/utils/io.py
+++ b/dcm2bids/utils/io.py
@@ -30,9 +30,8 @@ def save_json(filename, data):
 
 
 def write_txt(filename, lines):
-    with open(filename, "a+") as f:
+    with open(filename, "w") as f:
         f.write(f"{lines}\n")
-
 
 def valid_path(in_path, type="folder"):
     """Assert that file exists.

--- a/dcm2bids/utils/utils.py
+++ b/dcm2bids/utils/utils.py
@@ -112,7 +112,7 @@ def splitext_(path, extensions=None):
     return os.path.splitext(path)
 
 
-def run_shell_command(commandLine, log = True):
+def run_shell_command(commandLine, log=True):
     """ Wrapper of subprocess.check_output
     Returns:
         Run command with arguments and return its output
@@ -121,6 +121,7 @@ def run_shell_command(commandLine, log = True):
         logger = logging.getLogger(__name__)
         logger.info("Running: %s", " ".join(commandLine))
     return check_output(commandLine)
+
 
 def convert_dir(dir):
     """ Convert Direction
@@ -131,10 +132,13 @@ def convert_dir(dir):
         str: direction - bids format
     """
     return DEFAULT.entity_dir[dir]
+
+
 class TreePrinter:
     """
     Generates and prints a tree representation of a given a directory.
     """
+
     BRANCH = "│"
     LAST = "└──"
     JUNCTION = "├──"
@@ -169,15 +173,20 @@ class TreePrinter:
         Returns a list of strings representing the tree.
         """
         tree = []
-        entries = sorted(directory.iterdir(), key = lambda path: str(path).lower())
+        entries = sorted(directory.iterdir(), key=lambda path: str(path).lower())
         entries = sorted(entries, key=lambda entry: entry.is_file())
         entries_count = len(entries)
 
         for index, entry in enumerate(entries):
             connector = self.LAST if index == entries_count - 1 else self.JUNCTION
             if entry.is_dir():
-                sub_tree = self._generate_tree(entry, prefix=prefix +
-                                              (self.BRANCH_PREFIX if index != entries_count - 1 else self.SPACE))
+                sub_tree = self._generate_tree(
+                    entry,
+                    prefix=prefix
+                    + (
+                        self.BRANCH_PREFIX if index != entries_count - 1 else self.SPACE
+                    ),
+                )
                 tree.append(f"{prefix}{connector} {entry.name}{os.sep}")
                 tree.extend(sub_tree)
             else:

--- a/dcm2bids/utils/utils.py
+++ b/dcm2bids/utils/utils.py
@@ -112,15 +112,15 @@ def splitext_(path, extensions=None):
     return os.path.splitext(path)
 
 
-def run_shell_command(commandLine):
+def run_shell_command(commandLine, log = True):
     """ Wrapper of subprocess.check_output
     Returns:
         Run command with arguments and return its output
     """
-    logger = logging.getLogger(__name__)
-    logger.info("Running %s", commandLine)
+    if log:
+        logger = logging.getLogger(__name__)
+        logger.info("Running: %s", " ".join(commandLine))
     return check_output(commandLine)
-
 
 def convert_dir(dir):
     """ Convert Direction
@@ -131,3 +131,55 @@ def convert_dir(dir):
         str: direction - bids format
     """
     return DEFAULT.entity_dir[dir]
+class TreePrinter:
+    """
+    Generates and prints a tree representation of a given a directory.
+    """
+    BRANCH = "│"
+    LAST = "└──"
+    JUNCTION = "├──"
+    BRANCH_PREFIX = "│   "
+    SPACE = "    "
+
+    def __init__(self, root_dir):
+        self.root_dir = Path(root_dir)
+
+    def print_tree(self):
+        """
+        Prints the tree representation of the root directory and
+        its subdirectories and files.
+        """
+        tree = self._generate_tree(self.root_dir)
+        logger = logging.getLogger(__name__)
+        logger.info(f"Tree representation of {self.root_dir}{os.sep}")
+        logger.info(f"{self.root_dir}{os.sep}")
+        for item in tree:
+            logger.info(item)
+
+    def _generate_tree(self, directory, prefix=""):
+        """
+        Generates the tree representation of the <directory> recursively.
+
+        Parameters:
+        - directory: Path
+            The directory for which a tree representation is needed.
+        - prefix: str
+            The prefix to be added to each entry in the tree.
+
+        Returns a list of strings representing the tree.
+        """
+        tree = []
+        entries = sorted(directory.iterdir(), key = lambda path: str(path).lower())
+        entries = sorted(entries, key=lambda entry: entry.is_file())
+        entries_count = len(entries)
+
+        for index, entry in enumerate(entries):
+            connector = self.LAST if index == entries_count - 1 else self.JUNCTION
+            if entry.is_dir():
+                sub_tree = self._generate_tree(entry, prefix=prefix +
+                                              (self.BRANCH_PREFIX if index != entries_count - 1 else self.SPACE))
+                tree.append(f"{prefix}{connector} {entry.name}{os.sep}")
+                tree.extend(sub_tree)
+            else:
+                tree.append(f"{prefix}{connector} {entry.name}")
+        return tree

--- a/funfun/.bidsignore
+++ b/funfun/.bidsignore
@@ -1,0 +1,1 @@
+tmp_dcm2bids

--- a/funfun/.bidsignore
+++ b/funfun/.bidsignore
@@ -1,1 +1,0 @@
-tmp_dcm2bids


### PR DESCRIPTION
- [x] When dcm2bids_scaffold was ran multiple times, it appended data inside the generated files multiple times instead of overwriting it when using `--force`. 
- [x] The URL for the README was the the raw README, so HTML was being parsed, fixed that as well.
- [x] There was no logging, so I added some, including a tree representation of the output_dir in which the scaffold was done. No additional dependency was added.
- [x] Create a `.bidsignore` which include `tmp_dcm2bids` that is not valid, partially answering a comment brought up in #195 
 




 