### PR TITLE
[ENH] - Enable to automagically fill Sources key

### DIFF
--- a/dcm2bids/acquisition.py
+++ b/dcm2bids/acquisition.py
@@ -224,9 +224,20 @@ class Acquisition(object):
 
         # sidecarChanges
         for key, value in self.sidecarChanges.items():
-          # Inject IntendedFor id if "Sources" key is found in sidecarChanges and
-          # one of id key is also found.
-            data[key] = [item for sublist in [intendedForList.get(val) for val in value] for item in sublist] if key == "Sources" else value
+            if key == "Sources":
+                values = [intendedForList.get(val, val) for val in value]
+                # handle if nested list vs str
+                flat_value_list = []
+                for item in values:
+                    if isinstance(item, list):
+                        flat_value_list += item
+                    else:
+                        flat_value_list.append(item)
+                data[key] = flat_value_list
+            else:
+                data[key] = value
+
+
         return data
 
     @staticmethod

--- a/dcm2bids/acquisition.py
+++ b/dcm2bids/acquisition.py
@@ -149,12 +149,15 @@ class Acquisition(object):
     def setDstFile(self):
         """
         Return:
-            The destination filename formatted following the v1.7.0 BIDS entity key table
-            https://bids-specification.readthedocs.io/en/v1.7.0/99-appendices/04-entity-table.html
+            The destination filename formatted following the v1.8.0
+            BIDS entity key table
+            https://bids-specification.readthedocs.io/en/v1.8.0/99-appendices/04-entity-table.html
         """
         current_name = self.participant.prefix + self.suffix
         new_name = ''
-        current_dict = dict(x.split("-") for x in current_name.split("_") if len(x.split('-')) == 2)
+        current_dict = dict(
+          x.split("-") for x in current_name.split("_") if len(x.split('-')) == 2
+          )
         suffix_list = [x for x in current_name.split("_") if len(x.split('-')) == 1]
 
         for current_key in DEFAULT.entityTableKeys:
@@ -168,10 +171,11 @@ class Acquisition(object):
             new_name += f"_{current_key}-{current_dict[current_key]}"
 
         if current_dict:
-            self.logger.warning("Entity \"{}\"".format(list(current_dict.keys())) +
-                                " is not a valid BIDS entity.")
+            self.logger.warning(f"Entity \"{list(current_dict.keys())}\" is"
+                                "not a valid BIDS entity.")
 
-        new_name += f"_{'_'.join(suffix_list)}"  # Allow multiple single keys (without value)
+        # Allow multiple single keys (without value)
+        new_name += f"_{'_'.join(suffix_list)}"
 
         if len(suffix_list) != 1:
             self.logger.warning("There was more than one suffix found "
@@ -217,11 +221,14 @@ class Acquisition(object):
                     intendedValue = intendedValue + [intendedForList[index]]
                 else:
                     logging.warning(f"No id found for IntendedFor value '{index}'.")
-                    logging.warning(f"No sidecar changes for field IntendedFor will be made for json file {self.dstFile}.json with this id.")
+                    logging.warning(f"No sidecar changes for field IntendedFor"
+                                    f"will be made "
+                                    f"for json file {self.dstFile}.json with this id.")
                     logging.warning("Check: https://unfmontreal.github.io/Dcm2Bids/docs/how-to/create-config-file/#id-and-intendedFor.\n")
 
-            data["IntendedFor"] = [item for sublist in intendedValue for item in sublist]
-
+            data["IntendedFor"] = [
+                item for sublist in intendedValue for item in sublist
+            ]
         # sidecarChanges
         for key, value in self.sidecarChanges.items():
             if key == "Sources":
@@ -236,7 +243,6 @@ class Acquisition(object):
                 data[key] = flat_value_list
             else:
                 data[key] = value
-
 
         return data
 

--- a/dcm2bids/acquisition.py
+++ b/dcm2bids/acquisition.py
@@ -46,22 +46,9 @@ class Acquisition(object):
         self.modalityLabel = modalityLabel
         self.customEntities = customEntities
         self.srcSidecar = srcSidecar
-
-        if sidecarChanges is None:
-            self.sidecarChanges = {}
-        else:
-            self.sidecarChanges = sidecarChanges
-
-        if intendedFor is None:
-            self.intendedFor = IntendedFor
-        else:
-            self.intendedFor = intendedFor
-
-        if id is None:
-            self.id = None
-        else:
-            self.id = id
-
+        self.sidecarChanges = {} if sidecarChanges is None else sidecarChanges
+        self.intendedFor = IntendedFor if intendedFor is None else intendedFor
+        self.id = None if id is None else id
         self.dstFile = ''
 
     def __eq__(self, other):
@@ -237,8 +224,9 @@ class Acquisition(object):
 
         # sidecarChanges
         for key, value in self.sidecarChanges.items():
-            data[key] = value
-
+          # Inject IntendedFor id if "Sources" key is found in sidecarChanges and
+          # one of id key is also found.
+            data[key] = [item for sublist in [intendedForList.get(val) for val in value] for item in sublist] if key == "Sources" else value
         return data
 
     @staticmethod

--- a/dcm2bids/utils/utils.py
+++ b/dcm2bids/utils/utils.py
@@ -64,7 +64,7 @@ class DEFAULT(object):
     caseSensitive = True
 
     # Entity table:
-    # https://bids-specification.readthedocs.io/en/v1.7.0/99-appendices/04-entity-table.html
+    # https://bids-specification.readthedocs.io/en/v1.8.0/99-appendices/04-entity-table.html
     entityTableKeys = ["sub", "ses", "task", "acq", "ce", "rec", "dir",
                        "run", "mod", "echo", "flip", "inv", "mt", "part",
                        "recording"]


### PR DESCRIPTION
Following the new `id` method, I've improved how sidecarChanges work.
Instead of plainly parsing the `value` of `sidecarChanges`, it looks for the `Sources` key and then look for id to swap filename for.

Also possible to pass a plain string to Sources as well, it won't complain that there are no match with id as it happens with the `intendedFor` key atm.

Very useful when dealing with MP2RAGE data (ie UNIT1 file), see [this section of the BIDS spec](https://bids-specification.readthedocs.io/en/stable/appendices/qmri.html#mp2rage-specific-notes).

Shall some logging be added to inform the user about the changes happening within the sidecar file?