### PR TITLE
[ENH] Add major OS executables on new release

### DIFF
--- a/.github/workflows/make_binaries.yml
+++ b/.github/workflows/make_binaries.yml
@@ -58,7 +58,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
         run: |
           chmod u+x build/dcm2bids{_helper,_scaffold}
-          tar -cvf dcm2bids_${{ runner.os }}_${{ github.event.release.tag_name }}.tar.gz \
+          tar -czvf dcm2bids_${{ runner.os }}_${{ github.event.release.tag_name }}.tar.gz \
           build/dcm2bids \
           build/dcm2bids_helper \
           build/dcm2bids_scaffold
@@ -87,6 +87,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            download/artifact*
+            download/artifact/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/make_binaries.yml
+++ b/.github/workflows/make_binaries.yml
@@ -63,8 +63,7 @@ jobs:
 
       - name: Create archive for Windows
         if: startsWith(matrix.os, 'windows')
-        run: tar.exe acvf dcm2bids_${{ runner.os }}_${{ github.event.release.tag_name }}.zip \
-          -C build *.exe
+        run: tar.exe cavf dcm2bids_${{ runner.os }}_${{ github.event.release.tag_name }}.zip -C build *.exe
 
       - name: Upload binaries
         uses: actions/upload-artifact@v3

--- a/.github/workflows/make_binaries.yml
+++ b/.github/workflows/make_binaries.yml
@@ -59,13 +59,12 @@ jobs:
         run: |
           chmod u+x build/dcm2bids{_helper,_scaffold}
           tar -czvf dcm2bids_${{ runner.os }}_${{ github.event.release.tag_name }}.tar.gz \
-          build/dcm2bids \
-          build/dcm2bids_helper \
-          build/dcm2bids_scaffold
+          -C build dcm2bids dcm2bids_helper dcm2bids_scaffold
 
       - name: Create archive for Windows
         if: startsWith(matrix.os, 'windows')
-        run: tar.exe acvf dcm2bids_${{ runner.os }}_${{ github.event.release.tag_name }}.zip build/*.exe
+        run: tar.exe acvf dcm2bids_${{ runner.os }}_${{ github.event.release.tag_name }}.zip \
+          -C build *.exe
 
       - name: Upload binaries
         uses: actions/upload-artifact@v3

--- a/.github/workflows/make_binaries.yml
+++ b/.github/workflows/make_binaries.yml
@@ -1,0 +1,74 @@
+name: Build binaries
+
+# Controls when the workflow will run
+on:
+  # Trigger the workflow on push or pull request events only for master
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+  # Allow this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [macos-11, ubuntu-20.04, windows-latest] # not using latest based on https://github.com/Nuitka/Nuitka/issues/2240#issuecomment-1564030218
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      # Check-out repository
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+          architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements*.txt
+
+      - name: Build dcm2bids executable
+        uses: Nuitka/Nuitka-Action@main
+        with:
+          nuitka-version: main
+          script-name: dcm2bids/cli/dcm2bids.py
+          onefile: true
+          show-scons: false
+          output-file: dcm2bids
+
+      - name: Build dcm2bids_scaffold executable
+        uses: Nuitka/Nuitka-Action@main
+        with:
+          nuitka-version: main
+          script-name: dcm2bids/cli/dcm2bids_scaffold.py
+          onefile: true
+          show-scons: false
+          output-file: dcm2bids_scaffold
+
+      - name: Build dcm2bids_helper executable
+        uses: Nuitka/Nuitka-Action@main
+        with:
+          nuitka-version: main
+          script-name: dcm2bids/cli/dcm2bids_helper.py
+          show-scons: false
+          onefile: true
+          output-file: dcm2bids_helper
+     
+      - name: whats in there
+        run: ls build
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: dcm2bids_${{ runner.os }}
+          path: |
+            build/*.exe
+            build/dcm2bids
+            build/dcm2bids_helper
+            build/dcm2bids_scaffold
+            build/*.app/**/*

--- a/.github/workflows/make_binaries.yml
+++ b/.github/workflows/make_binaries.yml
@@ -55,9 +55,16 @@ jobs:
           output-file: dcm2bids_helper
 
       - name: Create archive for Linux
-        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
+        if: startsWith(matrix.os, 'ubuntu')
         run: |
-          chmod u+x build/dcm2bids{_helper,_scaffold}
+          chmod u+x build/dcm2bids{,_helper,_scaffold}
+          tar -czvf dcm2bids_debian-based_${{ github.event.release.tag_name }}.tar.gz \
+          -C build dcm2bids dcm2bids_helper dcm2bids_scaffold
+
+      - name: Create archive for macOS
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          chmod u+x build/dcm2bids{,_helper,_scaffold}
           tar -czvf dcm2bids_${{ runner.os }}_${{ github.event.release.tag_name }}.tar.gz \
           -C build dcm2bids dcm2bids_helper dcm2bids_scaffold
 

--- a/.github/workflows/make_binaries.yml
+++ b/.github/workflows/make_binaries.yml
@@ -1,13 +1,9 @@
-name: Build binaries
+name: Build + add binaries to release
 
 # Controls when the workflow will run
 on:
-  # Trigger the workflow on push or pull request events only for master
-  push:
-    branches: ["master"]
-  pull_request:
-    branches: ["master"]
-
+  release:
+    types: [published]
   # Allow this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -22,7 +18,6 @@ jobs:
     steps:
       # Check-out repository
       - uses: actions/checkout@v3
-
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -58,17 +53,37 @@ jobs:
           show-scons: false
           onefile: true
           output-file: dcm2bids_helper
-     
-      - name: whats in there
-        run: ls build
-
-      - name: Upload Artifacts
+      - name: Create archive for Linux and macOS
+        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
+        run: |
+          tar -cvf dcm2bids_${{ runner.os }}_${{ github.event.release.tag_name }}.tar.gz \
+          build/dcm2bids \
+          build/dcm2bids_helper \
+          build/dcm2bids_scaffold \
+          build/*.app/**/*
+      - name: Create archive for Windows
+        if: startsWith(matrix.os, 'windows')
+        run: zip dcm2bids_${{ runner.os }}_${{ github.event.release.tag_name }}.zip build/*.exe 
+      - name: Upload binaries
         uses: actions/upload-artifact@v3
         with:
-          name: dcm2bids_${{ runner.os }}
           path: |
-            build/*.exe
-            build/dcm2bids
-            build/dcm2bids_helper
-            build/dcm2bids_scaffold
-            build/*.app/**/*
+            dcm2bids*.zip
+            dcm2bids*.tar.gz
+
+  release:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download binaries
+        uses: actions/download-artifact@v3
+        with:
+          path: download
+      - run: ls -lR && echo $PWD
+      - name: Publish archives and packages
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            download/dcm2bids*/**
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/make_binaries.yml
+++ b/.github/workflows/make_binaries.yml
@@ -53,20 +53,20 @@ jobs:
           show-scons: false
           onefile: true
           output-file: dcm2bids_helper
+
       - name: Create archive for Linux
-        if: startsWith(matrix.os, 'ubuntu')
+        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
         run: |
+          chmod u+x build/dcm2bids{_helper,_scaffold}
           tar -cvf dcm2bids_${{ runner.os }}_${{ github.event.release.tag_name }}.tar.gz \
           build/dcm2bids \
           build/dcm2bids_helper \
           build/dcm2bids_scaffold
-      - name: Create archive for Linux
-        if: startsWith(matrix.os, 'macos')
-        run: |
-          tar -cvf dcm2bids_${{ runner.os }}_${{ github.event.release.tag_name }}.tar.gz build/*.app/**/*
+
       - name: Create archive for Windows
         if: startsWith(matrix.os, 'windows')
-        run: zip dcm2bids_${{ runner.os }}_${{ github.event.release.tag_name }}.zip build/*.exe 
+        run: tar.exe acvf dcm2bids_${{ runner.os }}_${{ github.event.release.tag_name }}.zip build/*.exe
+
       - name: Upload binaries
         uses: actions/upload-artifact@v3
         with:
@@ -82,11 +82,11 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           path: download
-      - run: ls -lR && echo $PWD
+
       - name: Publish archives and packages
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            download/dcm2bids*/**
+            download/artifact*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/make_binaries.yml
+++ b/.github/workflows/make_binaries.yml
@@ -53,14 +53,17 @@ jobs:
           show-scons: false
           onefile: true
           output-file: dcm2bids_helper
-      - name: Create archive for Linux and macOS
-        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
+      - name: Create archive for Linux
+        if: startsWith(matrix.os, 'ubuntu')
         run: |
           tar -cvf dcm2bids_${{ runner.os }}_${{ github.event.release.tag_name }}.tar.gz \
           build/dcm2bids \
           build/dcm2bids_helper \
-          build/dcm2bids_scaffold \
-          build/*.app/**/*
+          build/dcm2bids_scaffold
+      - name: Create archive for Linux
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          tar -cvf dcm2bids_${{ runner.os }}_${{ github.event.release.tag_name }}.tar.gz build/*.app/**/*
       - name: Create archive for Windows
         if: startsWith(matrix.os, 'windows')
         run: zip dcm2bids_${{ runner.os }}_${{ github.event.release.tag_name }}.zip build/*.exe 


### PR DESCRIPTION
This PR adds a GH workflow that builds and adds executable files for the 3 main programs, namely `dcm2bids`, `dcm2bids_helper`, and `dcm2bids_scaffold`, when a new release is published. 

This workflow will run **only** when there is a new release and will build executables for Windows, Linux and macOS. I have set the executable bit, so technically `chmod u+x dcm2bids*` won't be needed as well. 

See https://github.com/SamGuay/Dcm2Bids/releases/tag/3.0.0-alpharc for an example.

Caveat: Windows and macOS builds haven't been tested. Linux bin works properly on Ubuntu 20.04 and up. Ideally, the build would be done on CentOS 7 but GH doesn't have CentOS runners... so the bins might need to be recompile to work on HPC running RHEL-based OSes.