### PR TITLE
prevent doc deployment by pushing to master

### DIFF
--- a/.github/workflows/publish_doc.yaml
+++ b/.github/workflows/publish_doc.yaml
@@ -1,10 +1,15 @@
 name: Publish documentation
 
+# Controls when the workflow will run
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [published]
+  # Allow this workflow manually from the Actions tab
+  workflow_dispatch:
   pull_request:
+    branches:
+    - master
+    - 'releases/**'
 
 jobs:
   build:


### PR DESCRIPTION
Will stop the documentation to be constantly updated unless the specific conditions are met.