### PR TITLE
[MAINT] validate citation.cff

### DIFF
--- a/.github/workflows/cff_validation.yml
+++ b/.github/workflows/cff_validation.yml
@@ -1,0 +1,20 @@
+---
+name: cff_validation
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  cff_validation:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Check whether the citation metadata from CITATION.cff is valid
+      uses: citation-file-format/cffconvert-github-action@2.0.0
+      with:
+        args: --validate
+


### PR DESCRIPTION
- closes none

- add a github action workflow to make sure that the citation.cff validate conforms to the its schema

## benefit

avoid having failed zenodo releases when the citation.cff is invalid