### PR TITLE
Fix typos in scaffold files

### DIFF
--- a/dcm2bids/cli/dcm2bids_scaffold.py
+++ b/dcm2bids/cli/dcm2bids_scaffold.py
@@ -80,7 +80,7 @@ def main():
                                                )
               )
     # dataset_description
-    write_txt(opj(args.output_dir, "dataset_description"),
+    write_txt(opj(args.output_dir, "dataset_description.json"),
               bids_starter_kit.dataset_description.replace("BIDS_VERSION",
                                                            DEFAULT.bids_version))
 

--- a/dcm2bids/utils/scaffold.py
+++ b/dcm2bids/utils/scaffold.py
@@ -31,9 +31,7 @@ class bids_starter_kit(object):
     "age": {
         "LongName": "",
         "Description": "age of the participant",
-        "Levels": [],
-        "Units": "years",
-        "TermURL": ""
+        "Units": "years"
     },
     "sex": {
         "LongName": "",
@@ -41,22 +39,16 @@ class bids_starter_kit(object):
         "Levels": {
             "M": "male",
             "F": "female"
-        },
-        "Units": "",
-        "TermURL": ""
+        }
     },
     "group": {
         "LongName": "",
-        "Description": "Group of the participant",
+        "Description": "experimental group the participant belonged to",
         "Levels": {
-            "control": "Control",
-            "patient": "Patient"
-        },
-        "Units": "",
-        "TermURL": ""
-    },
-
-
+            "control": "control",
+            "patient": "patient"
+        }
+    }
 }
 """
 


### PR DESCRIPTION
As soon as a participant `sub-*` directory is added, the validator will do its job and validate the dataset and won't trigger errors in the files generated by `dcm2bids_scaffold`. 

Though, two warnings should come up, which is good as people need to fill these up: 

> Warning 1: [Code 102] TOO_FEW_AUTHORS
> Click here for more information about this issue
> The Authors field of dataset_description.json should contain an array of fields - with one author per field. This was triggered based on the presence of only one author field. Please ignore if all contributors are already properly listed.

> Warning 2: [Code 115] EMPTY_DATASET_NAME
> Click here for more information about this issue
> The Name field of dataset_description.json is present but empty of visible characters.

Closing #254 