### PR TITLE
Fix release tags in GHA

### DIFF
--- a/.github/workflows/publish_doc.yaml
+++ b/.github/workflows/publish_doc.yaml
@@ -8,6 +8,8 @@ on:
       - master
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
+  release:
+    types: [published]
   # Allow this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -54,13 +56,25 @@ jobs:
       - name: Build API reference
         run: pdocs as_markdown -o docs/ dcm2bids --overwrite
 
-      - name: Build docs for specific release
+      - name: Build docs for new release
         if: github.event_name == 'release'
         run: |
+          echo "Version: $(dcm2bids -v | awk '/dcm2bids/ {print $3}')"
+          echo "Version: ${{ github.ref_name }}"
           mike deploy -p ${{ github.ref_name }} latest -u
+
+      # This might be also triggered for new release as it pushes a new tag,
+      # but it's ok even if there is an error on this run, the previous run is ok.
+      - name: Build docs for releases already deployed
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        run: |
+          echo "Version: $(dcm2bids -v | awk '/dcm2bids/ {print $3}')"
+          echo "Version: ${{ github.ref_name }}"
+          mike deploy -p ${{ github.ref_name }}
 
       - name: Deploy dev version
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
           VERSION=$(dcm2bids -v | awk '/dcm2bids/ {print $3}')
+          echo "Version: $VERSION"
           mike deploy -p $VERSION dev -u


### PR DESCRIPTION
Instead of doing manual release of the tags in the docs, versioning will now be automated.