### PR TITLE
[ENH] Add logging when dcm2niix skips dcm images

### DIFF
--- a/dcm2bids/dcm2niix_gen.py
+++ b/dcm2bids/dcm2niix_gen.py
@@ -142,12 +142,12 @@ class Dcm2niixGen(object):
                     shutil.rmtree(self.rm_tmp_dir)
                     self.logger.info("Temporary dicom directory removed.")
 
-                if "Warning" in output or "Error" in output:
+                if "Warning" in output or "Error" in output or "Skipping" in output:
                     self.logger.info("Log from dcm2niix execution")
-                    if "Warning" in output:
-                        self.logger.warning(f"{output}")
-                    else:
+                    if "Error" in output:
                         self.logger.error(f"{output}")
+                    else:
+                        self.logger.warning(f"{output}")
                 else:
                     self.logger.debug(f"\n{output}")
                     self.logger.info("Check log file for dcm2niix output\n")


### PR DESCRIPTION
When dcm2niix skips some dcm images dcm2bids will issue a warning.