### PR TITLE
FIX: explicitly raise error if subprocess fails

### DIFF
--- a/dcm2bids/utils/utils.py
+++ b/dcm2bids/utils/utils.py
@@ -5,7 +5,7 @@ import csv
 import logging
 import os
 from pathlib import Path
-from subprocess import Popen, PIPE
+from subprocess import PIPE, CalledProcessError, Popen
 
 
 class DEFAULT(object):
@@ -151,6 +151,11 @@ def run_shell_command(commandLine, log=True):
 
     pipes = Popen(commandLine, stdout=PIPE, stderr=PIPE)
     std_out, std_err = pipes.communicate()
+
+    if pipes.returncode != 0:
+        if log:
+            logger.error("Command failed with error: %s", std_err.decode())
+        raise CalledProcessError(pipes.returncode, commandLine, output=std_out, stderr=std_err)
 
     return std_out
 


### PR DESCRIPTION
Tangentially related to #333 

Let's say I tried to run `dcm2bids` on a dicom archive. 

As #333 points out, this fails because `dcm2niix` doesn't recognize archives (but this is beside the point of this PR).

So what happens? Well `dcm2niix` doesn't generate any nifti files, and returns a non-zero exit code, but `dcm2bids` plugs along with its program as usual. 

Eventually the user will get a bunch of the `no pairing` messages followed by a warning that `"no pairings were found. check your config file"` . i.e.:

```
INFO    | --- dcm2bids start ---
...
INFO    | Running: dcm2niix -b y -ba y -z y -f %3s_%f_%p_%t -o /bids/tmp_dcm2bids/sub-1063_ses-sixmonth /dicoms
INFO    | Check log file for dcm2niix output

INFO    | SIDECAR PAIRING
WARNING | NO PAIRING WAS FOUND. BIDS FOLDER "/BIDS/SUB-1063/SES-SIXMONTH" WON'T BE CREATED. CHECK YOUR CONFIG FILE.

INFO    | Logs saved in /bids/tmp_dcm2bids/log/sub-1063_ses-sixmonth_20250314-165850.log
INFO    | --- dcm2bids end ---
```

-------------------------------

But the issue isn't with the config file, the issue is that dcm2niix failed! 

I think we should make that explicitly clear to the user, as it's the true source of the `dcm2bids` failure and is much more helpful!


This PR makes that clear. On this branch, this is now what I would see when running `dcm2bids` with those problematic files:


```
root@76ce3c4faacd:/dcm2bids# dcm2bids_helper -d /dicoms -o /bids
INFO    | --- dcm2bids_helper start ---
INFO    | Running the following command: /venv/bin/dcm2bids_helper -d /dicoms -o /bids
INFO    | OS version: Linux-6.10.14-linuxkit-x86_64-with-glibc2.36
INFO    | Python version: 3.12.3 | packaged by conda-forge | (main, Apr 15 2024, 18:38:13) [GCC 12.3.0]
INFO    | dcm2bids version: 3.2.0
INFO    | dcm2niix version: v1.0.20240202
INFO    | Checking for software update
INFO    | Currently using the latest version of dcm2bids.
WARNING | A newer version exists for dcm2niix: v1.0.20241211
WARNING | You should update it -> https://github.com/rordenlab/dcm2niix.
INFO    | Running: dcm2niix -b y -ba y -z y -f %3s_%f_%p_%t -o /bids/tmp_dcm2bids/helper /dicoms
ERROR   | Command failed with error: Error: Unable to find any DICOM images in /dicoms (or subfolders 5 deep)

Traceback (most recent call last):
  File "/venv/bin/dcm2bids_helper", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/dcm2bids/dcm2bids/cli/dcm2bids_helper.py", line 108, in main
    rsl = app.run(force=args.overwrite)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/dcm2bids/dcm2bids/dcm2niix_gen.py", line 99, in run
    self.execute()
  File "/dcm2bids/dcm2bids/dcm2niix_gen.py", line 134, in execute
    output = run_shell_command(cmd)
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/dcm2bids/dcm2bids/utils/utils.py", line 158, in run_shell_command
    raise CalledProcessError(pipes.returncode, commandLine, output=std_out, stderr=std_err)
subprocess.CalledProcessError: Command '['dcm2niix', '-b', 'y', '-ba', 'y', '-z', 'y', '-f', '%3s_%f_%p_%t', '-o', PosixPath('/bids/tmp_dcm2bids/helper'), '/dicoms']' returned non-zero exit status 2.
```