### PR TITLE
DOC: give commands for Mac/Win too

### DIFF
--- a/docs/tutorial/first-steps.md
+++ b/docs/tutorial/first-steps.md
@@ -299,9 +299,18 @@ an intuitive organization (with sub-folders for sessions, as necessary).
     === "Commands"
 
         1. Download the zipped file from <https://github.com/neurolabusc/dcm_qa_nih/archive/refs/heads/master.zip>.
-        ```sh
-        wget -O dcm_qa_nih-master.zip https://github.com/neurolabusc/dcm_qa_nih/archive/refs/heads/master.zip
-        ```
+        === "Linux"
+            ```sh
+            wget -O dcm_qa_nih-master.zip https://github.com/neurolabusc/dcm_qa_nih/archive/refs/heads/master.zip
+            ```
+        === "Mac"
+            ```sh
+            curl -L -o dcm_qa_nih-master.zip https://github.com/neurolabusc/dcm_qa_nih/archive/refs/heads/master.zip
+            ```
+        === "Windows"
+            ```sh
+            curl -L -o dcm_qa_nih-master.zip https://github.com/neurolabusc/dcm_qa_nih/archive/refs/heads/master.zip
+            ```
 
         2. Extract/unzip the zipped file into **sourcedata/**.
         ```sh


### PR DESCRIPTION
`wget` doesn't come installed on MacOS by default, but curl should do fine.

 IIRC Windows comes with `curl` pre-installed too, so I just went ahead and added a content tab for Windows while I was at it, but I don't actually have a windows computer/VM nearby to test the command!

if this looks good, we could extend these content tabs for other commands in the tutorial that might be OS specific (e.g. `mv` and `unzip` won't work on windows by default).

<img width="719" alt="Screenshot 2025-03-14 at 4 42 46 PM" src="https://github.com/user-attachments/assets/30171566-6b80-44e0-bf66-1195ba0e3001" />

