### PR TITLE
ENH] update github action

### DIFF
--- a/.github/workflows/publish_doc.yaml
+++ b/.github/workflows/publish_doc.yaml
@@ -37,7 +37,7 @@ jobs:
         run: echo "::set-output name=dir::$(pip cache dir)"
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-doc.txt') }}


### PR DESCRIPTION
Github action: actions/cache is deprecated. Update to 4.0.0