### PR TITLE
FIX: skipping dcm2niix shouldn't allow collisions

### DIFF
--- a/dcm2bids/dcm2niix_gen.py
+++ b/dcm2bids/dcm2niix_gen.py
@@ -9,6 +9,7 @@ import shutil
 import tarfile
 import zipfile
 from glob import glob
+from pathlib import Path
 
 from dcm2bids.utils.io import valid_path
 from dcm2bids.utils.utils import DEFAULT, run_shell_command
@@ -153,8 +154,11 @@ class Dcm2niixGen(object):
                     self.logger.info("Check log file for dcm2niix output\n")
         else:
             for dicomDir in self.dicom_dirs:
-                shutil.copytree(dicomDir, self.output_dir, dirs_exist_ok=True)
-                cmd = ['cp', '-r', dicomDir, self.output_dir]
-                self.logger.info("Running: %s", " ".join(str(item) for item in cmd))
+                for filepath in Path(dicomDir).rglob("*"):
+                    if filepath.is_file():
+                        shutil.copy(filepath, Path(self.output_dir / f"{Path(dicomDir).name}_{filepath.name}"), follow_symlinks=True)
+                # shutil.copytree(dicomDir, self.output_dir, dirs_exist_ok=True)
+                # cmd = ['cp', '-r', dicomDir, self.output_dir]
+                # self.logger.info("Running: %s", " ".join(str(item) for item in cmd))
 
             self.logger.info("Not running dcm2niix\n")

--- a/dcm2bids/dcm2niix_gen.py
+++ b/dcm2bids/dcm2niix_gen.py
@@ -157,8 +157,6 @@ class Dcm2niixGen(object):
                 for filepath in Path(dicomDir).rglob("*"):
                     if filepath.is_file():
                         shutil.copy(filepath, Path(self.output_dir / f"{Path(dicomDir).name}_{filepath.name}"), follow_symlinks=True)
-                # shutil.copytree(dicomDir, self.output_dir, dirs_exist_ok=True)
-                # cmd = ['cp', '-r', dicomDir, self.output_dir]
-                # self.logger.info("Running: %s", " ".join(str(item) for item in cmd))
+                self.logger.info("Copying NIFTI files/sidecars from: %s", dicomDir)
 
             self.logger.info("Not running dcm2niix\n")

--- a/dcm2bids/sidecar.py
+++ b/dcm2bids/sidecar.py
@@ -302,9 +302,9 @@ class SidecarPairing(object):
         def compare_list(name, pattern):
             try:
                 subResult = [
-                        len(name) == len(pattern),
-                        isinstance(pattern, list),
-                        ]
+                    len(name) == len(pattern),
+                    isinstance(pattern, list),
+                ]
                 for subName, subPattern in zip(name, pattern):
                     subResult.append(compare(subName, subPattern))
             except Exception:
@@ -436,8 +436,8 @@ class SidecarPairing(object):
                     acquisitions.append(acq)
 
                 self.logger.info(
-                  f"{acq.dstFile.replace(f'{acq.participant.prefix}-', '')}"
-                  f"  <-  {sidecarName}")
+                    f"{acq.dstFile.replace(f'{acq.participant.prefix}-', '')}"
+                    f"  <-  {sidecarName}")
 
             elif len(valid_descriptions) == 0:
                 self.logger.info(f"No Pairing  <-  {sidecarName}")
@@ -578,6 +578,6 @@ class SidecarPairing(object):
                 dup = dup[0:-1]
 
             for runNum, acqInd in enumerate(dup):
-                runStr = templateDup.format(runNum+1)
+                runStr = templateDup.format(runNum + 1)
                 self.acquisitions[acqInd].custom_entities += runStr
                 self.acquisitions[acqInd].setDstFile()


### PR DESCRIPTION
ran into an issue where, when running dcm2bids on multiple NIFTI-only directories with similar naming structures (i.e. series 1 named '1.nii.gz', series 2 named '2.nii.gz', etc.) would collide names when using shutil.copytree(). the solution here is to add a prefix to each file that's the base path of the dicom directory