### PR TITLE
[Hotfix] Include data package in the actual build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,14 @@ dcm2bids = "dcm2bids.cli.dcm2bids:main"
 dcm2bids_helper = "dcm2bids.cli.dcm2bids_helper:main"
 dcm2bids_scaffold = "dcm2bids.cli.dcm2bids_scaffold:main"
 
+[tool.setuptools]
+include-package-data = true
+
 [tool.setuptools.packages.find]
 exclude = ["tests*"]
+
+[tool.setuptools.package-data]
+dcm2bids = ['utils/schema_data/*.json']
 
 [tool.setuptools.dynamic]
 version = {attr = "dcm2bids.version.__version__"}


### PR DESCRIPTION
During the change to pyproject.toml, we forgot to include data package for the BIDS schema .JSON. 
Thanks to author of #396 for highlighting it, this will fix it. 