### PR TITLE
Decode dcm2niix output with errors=replace

### DIFF
--- a/dcm2bids/dcm2niix_gen.py
+++ b/dcm2bids/dcm2niix_gen.py
@@ -131,12 +131,7 @@ class Dcm2niixGen(object):
                 cmd = ['dcm2niix', *shlex.split(self.options),
                        '-o', self.output_dir, dicomDir]
 
-                output = run_shell_command(cmd)
-
-                try:
-                    output = output.decode()
-                except Exception:
-                    pass
+                output = run_shell_command(cmd).decode(errors="replace")
 
                 if self.rm_tmp_dir:
                     shutil.rmtree(self.rm_tmp_dir)

--- a/tests/test_dcm2niix.py
+++ b/tests/test_dcm2niix.py
@@ -39,3 +39,18 @@ def test_dcm2niix_run():
 
     if os.name != 'nt':
         tmpDir.cleanup()
+
+
+def test_execute_handles_non_utf8_output(tmp_path, monkeypatch, caplog):
+    """dcm2niix output that is not valid UTF-8 must not crash the warning check."""
+    import dcm2bids.dcm2niix_gen as gen
+
+    monkeypatch.setattr(gen, "run_shell_command", lambda cmd: b"\xff Warning: x")
+    dicomDir = tmp_path / "dicom"
+    dicomDir.mkdir()
+
+    app = Dcm2niixGen([str(dicomDir)], tmp_path)
+    with caplog.at_level("WARNING"):
+        app.execute()
+
+    assert "Warning: x" in caplog.text


### PR DESCRIPTION
Fixes #382. Decodes dcm2niix output with `errors="replace"` so non-UTF-8 bytes no longer raise `TypeError` in the warning check.
